### PR TITLE
Rename type column in LockboxTransaction

### DIFF
--- a/app/models/lockbox_action.rb
+++ b/app/models/lockbox_action.rb
@@ -2,4 +2,6 @@ class LockboxAction < ApplicationRecord
   belongs_to :lockbox_partner
   has_many :lockbox_transactions
   has_many :notes, as: :notable
+
+  ACTION_TYPES = [ :add_cash, :reconcile, :support_client ].freeze
 end

--- a/app/models/lockbox_transaction.rb
+++ b/app/models/lockbox_transaction.rb
@@ -1,3 +1,5 @@
 class LockboxTransaction < ApplicationRecord
   belongs_to :lockbox_action
+
+  BALANCE_EFFECTS = [ :debit, :credit ].freeze
 end

--- a/db/migrate/20190421201237_change_column_in_lockbox_transactions.rb
+++ b/db/migrate/20190421201237_change_column_in_lockbox_transactions.rb
@@ -1,0 +1,5 @@
+class ChangeColumnInLockboxTransactions < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :lockbox_transactions, :type, :balance_effect
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_21_191047) do
+ActiveRecord::Schema.define(version: 2019_04_21_201237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2019_04_21_191047) do
 
   create_table "lockbox_transactions", force: :cascade do |t|
     t.date "eff_date"
-    t.string "type"
+    t.string "balance_effect"
     t.string "category"
     t.integer "amount"
     t.bigint "lockbox_action_id"


### PR DESCRIPTION
https://github.com/MidwestAccessCoalition/lockbox_rails/issues/24

- renames the type column on LockboxTransaction model to avoid naming errors (`type` isn't allowed 😬 )
- add constants to LockboxAction and LockboxTransaction