### PR TITLE
Explicitly specify I18n localization for Money gem

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,0 +1,3 @@
+# This will use the money formatting specified by default in rails-i18n, e.g.:
+#   Money.new(10_000_00, 'USD').format # => $10,000.00
+Money.locale_backend = :i18n


### PR DESCRIPTION
Resolves https://github.com/MidwestAccessCoalition/lockbox_rails/issues/76

This won't affect behavior in any way, but will ensure that localization behavior remains unchanged if we update the money gem ([see their documentation](https://github.com/RubyMoney/money#deprecation)) and will silence the warning that currently gets logged every time money localization gets called.