### PR TITLE
Account signup and management 82

### DIFF
--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -6,7 +6,6 @@ $color-primary: #4385c4;
   background: $devise-background;
   overflow: auto;
   display: flex;
-  align-items: center;
   top: 0;
   margin: 0 auto;
   @media only screen and (min-width: $mobile-width) {

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -12,9 +12,12 @@ class Users::PasswordsController < Devise::PasswordsController
   # end
 
   # GET /resource/password/edit?reset_password_token=abcdef
-  # def edit
-  #   super
-  # end
+  def edit
+    @resource = resource_class.find_by(
+      reset_password_token: params[:reset_password_token]
+    )
+    super
+  end
 
   # PUT /resource/password
   def update

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  def update
+    super do |resource|
+      if resource.errors.empty?
+        resource.update(update_password_params)
+      end
+    end
+  end
+
+  protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  def update_password_params
+    # Devise does not use these params to update the password itself, hence
+    # the absence of password and password_confirmation
+    params.require(:user).permit(:name)
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,7 +2,7 @@
 
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+  before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
   # def new
@@ -58,5 +58,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(resource)
     new_user_session_path
+  end
+
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,7 +4,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]
 
-  layout 'application', only: :edit
+  layout 'application', only: [:edit, :update]
 
   # GET /resource/sign_up
   # def new

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,6 +4,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]
 
+  layout 'application', only: :edit
+
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,10 @@ class User < ApplicationRecord
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
 
+  def has_signed_in?
+    !!last_sign_in_at
+  end
+
   private
 
   def password_required?

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,7 +4,8 @@
   <%= devise_error_messages! %>
   <%= f.hidden_field :reset_password_token %>
 
-  <% unless resource.password.present? %>
+  <% # Coercing to a boolean because #nonzero? does not return a boolean %>
+  <% unless !!@resouce&.sign_in_count&.nonzero? %>
     <div class="field">
       <%= f.label :name %><br />
       <%= f.text_field :name %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,6 +4,13 @@
   <%= devise_error_messages! %>
   <%= f.hidden_field :reset_password_token %>
 
+  <% unless resource.password.present? %>
+    <div class="field">
+      <%= f.label :name %><br />
+      <%= f.text_field :name %>
+    </div>
+  <% end %>
+
   <div class="field">
     <%= f.label :password, "New password" %><br />
     <% if @minimum_password_length %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,8 +4,8 @@
   <%= devise_error_messages! %>
   <%= f.hidden_field :reset_password_token %>
 
-  <% # Coercing to a boolean because #nonzero? does not return a boolean %>
-  <% unless !!@resouce&.sign_in_count&.nonzero? %>
+  <% # The user should be able to set a name the first time they confirm the account, but not if they request a subsequent password reset %>
+  <% unless @resource&.has_signed_in? %>
     <div class="field">
       <%= f.label :name %><br />
       <%= f.text_field :name %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,6 +4,11 @@
   <%= devise_error_messages! %>
 
   <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,6 @@
-<h2>Account</h2>
+<div>
+  <h2>Account</h2>
+</div>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= devise_error_messages! %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users, skip: [:registrations], controllers: {
+  devise_for :users, controllers: {
     confirmations: 'users/confirmations',
     registrations: 'users/registrations'
   }
-  as :user do
-    get '/users/edit', to: 'devise/registrations#edit', as: :edit_user_registration
-    patch '/users', to: 'devise/registrations#update', as: :user_registration
-    put '/users', to: 'devise/registrations#update'
-  end
 
   resources :support_requests, only: [:new, :create]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     confirmations: 'users/confirmations',
+    passwords: 'users/passwords',
     registrations: 'users/registrations'
   }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,4 +2,21 @@ require 'rails_helper'
 
 describe User, type: :model do
   it { is_expected.to belong_to(:lockbox_partner).optional }
+
+  describe "#has_signed_in?" do
+    let(:user) { FactoryBot.build(:user, last_sign_in_at: last_sign_in_at) }
+    subject { user.has_signed_in? }
+
+    context "when last_sign_in_at is nil" do
+      let(:last_sign_in_at) { nil }
+
+      it { is_expected.to be false }
+    end
+
+    context "when last_sign_in_at is not nil" do
+      let(:last_sign_in_at) { 1.hour.ago }
+
+      it { is_expected.to be true }
+    end
+  end
 end


### PR DESCRIPTION
Resolves #82 
* Allow user to edit name on account management page
* Allow user to edit name when setting initial password
* Use application layout for account management page
* Fix CSS issue that caused devise forms to render incorrectly when additional fields were added (possibly without additional fields given a small enough screen)


![Screenshot_20190526_145226](https://user-images.githubusercontent.com/8214544/58386505-3458d580-7fc6-11e9-867f-fcbef80bddb5.png)
![Screenshot_20190526_145252](https://user-images.githubusercontent.com/8214544/58386506-36bb2f80-7fc6-11e9-877a-2a580bf6178d.png)
