### PR TITLE
Split out lockbox partner address fields

### DIFF
--- a/app/controllers/lockbox_partners_controller.rb
+++ b/app/controllers/lockbox_partners_controller.rb
@@ -19,6 +19,8 @@ class LockboxPartnersController < ApplicationController
   private
 
   def lockbox_params
-    params.require(:lockbox_partner).permit(:name, :address, :phone_number)
+    params.require(:lockbox_partner)
+          .permit(:name, :phone_number, :street_address,
+                  :city, :state, :zip_code)
   end
 end

--- a/app/models/lockbox_transaction.rb
+++ b/app/models/lockbox_transaction.rb
@@ -19,4 +19,8 @@ class LockboxTransaction < ApplicationRecord
     FOOD       = 'food',
     ADJUSTMENT = 'adjustment'
   ].freeze
+
+  def eff_date
+    lockbox_action.eff_date
+  end
 end

--- a/app/views/dashboard/_admin_dash.html.erb
+++ b/app/views/dashboard/_admin_dash.html.erb
@@ -1,7 +1,7 @@
 <div class="lockbox-partner container clearfix">
   <div>
     <p>
-      <strong>City</strong>
+      <strong><%= lockbox_partner.city %></strong>
     </p>
   </div>
   <h3>

--- a/app/views/dashboard/_lockbox_partner.html.erb
+++ b/app/views/dashboard/_lockbox_partner.html.erb
@@ -1,7 +1,7 @@
 <div class="lockbox-partner clearfix">
   <div>
     <p>
-      <strong>City</strong>
+      <strong><%= lockbox_partner.city %></strong>
     </p>
   </div>
   <h3>

--- a/app/views/lockbox_partners/new.html.erb
+++ b/app/views/lockbox_partners/new.html.erb
@@ -5,8 +5,20 @@
       <%= f.text_field :name, class: 'form-control' %>
     </div>
     <div class="form-group">
-      <%= f.label :address %>
-      <%= f.text_field :address, class: 'form-control'  %>
+      <%= f.label :street_address %>
+      <%= f.text_field :street_address, class: 'form-control'  %>
+    </div>
+    <div class="form-group">
+      <%= f.label :city %>
+      <%= f.text_field :city, class: 'form-control'  %>
+    </div>
+    <div class="form-group">
+      <%= f.label :state %>
+      <%= f.text_field :state, class: 'form-control'  %>
+    </div>
+    <div class="form-group">
+      <%= f.label :zip_code %>
+      <%= f.text_field :zip_code, class: 'form-control'  %>
     </div>
     <div class="form-group">
       <%= f.label :phone_number %>

--- a/app/views/lockbox_partners/show.html.erb
+++ b/app/views/lockbox_partners/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div>
-    <p><strong>City</strong></p>
+    <p><strong><%= @lockbox_partner.city %></strong></p>
   </div>
   <h3>
     <%= @lockbox_partner.name %><span class="pull-right">$ <%= @lockbox_partner.balance %></span>

--- a/db/migrate/20190611035717_add_address_field_to_lockbox_partner.rb
+++ b/db/migrate/20190611035717_add_address_field_to_lockbox_partner.rb
@@ -1,0 +1,10 @@
+class AddAddressFieldToLockboxPartner < ActiveRecord::Migration[6.0]
+  def change
+    add_column :lockbox_partners, :street_address, :string
+    add_column :lockbox_partners, :city, :string
+    add_column :lockbox_partners, :state, :string
+    add_column :lockbox_partners, :zip_code, :string
+
+    remove_column :lockbox_partners, :address
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_09_192617) do
+ActiveRecord::Schema.define(version: 2019_06_11_035717) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,10 @@ ActiveRecord::Schema.define(version: 2019_06_09_192617) do
     t.string "phone_number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "street_address"
+    t.string "city"
+    t.string "state"
+    t.string "zip_code"
   end
 
   create_table "lockbox_transactions", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,9 @@ LOCKBOX_PARTNERS = [
 
 LOCKBOX_PARTNERS.map do |partner_name, partner_user_email|
   lockbox_partner = LockboxPartner.where(name: partner_name).first_or_create!(
-    address: Faker::Address.full_address,
+    city: Faker::Address.city,
+    state: Faker::Address.state,
+    zip_code: Faker::Address.zip_code,
     phone_number: Faker::PhoneNumber.phone_number
   )
 

--- a/lib/add_cash_to_lockbox.rb
+++ b/lib/add_cash_to_lockbox.rb
@@ -21,7 +21,6 @@ class AddCashToLockbox
       end
 
       lockbox_transaction = lockbox_action.lockbox_transactions.create(
-        eff_date: eff_date,
         amount_cents: amount_cents,
         balance_effect: LockboxTransaction::CREDIT
       )

--- a/spec/factories/lockbox_partners.rb
+++ b/spec/factories/lockbox_partners.rb
@@ -1,8 +1,11 @@
 FactoryBot.define do
   factory :lockbox_partner do
-    name         { Faker::Company.name }
-    address      { Faker::Address.full_address }
-    phone_number { Faker::PhoneNumber.phone_number }
+    name           { Faker::Company.name }
+    street_address { Faker::Address.street_address }
+    city           { Faker::Address.city }
+    state          { Faker::Address.state }
+    zip_code       { Faker::Address.zip_code }
+    phone_number   { Faker::PhoneNumber.phone_number }
 
     trait :active do
       # The user needs to be confirmed, but currently the user factory does this


### PR DESCRIPTION
## Primary Change
In numerous places in the views, we need to isolate the city from the address. This PR splits the address field into four fields:

- street_address
- city
- state
- zip_code

Follow ups...
- State should correspond with a list of states and should be a select drop down

### Secondary Change

- fixed broken tests
- rm assignment to a column that doesn't exist (LockboxTransaction#eff_date)