### PR TITLE
Fixes placement of remember me

### DIFF
--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -25,9 +25,6 @@ html, body {
     width: 400px;
     margin: 6em auto;
     height: 100%;
-    input {
-      width: 100%;
-    }
     .horizontal-rule {
       width: 100%;
       height: 15px;

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,20 +13,22 @@
       <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
     </div>
 
-    <a title="Forgot your password?" href="<%= new_password_path(resource_name) %>"
-        class="forgot">Forgot your password?</a>
-
     <div>
       <% if devise_mapping.rememberable? -%>
         <div class="form-group">
           <div class="form-check">
-            <%= f.check_box :remember_me, class: 'form-control form-check-input' %>
+            <%= f.check_box :remember_me, class: 'form-check-input' %>
             <%= f.label :remember_me, class: 'form-check-label' %>
           </div>
         </div>    
       <% end -%>
     </div>
 
-    <%= f.submit "Log in", class: 'btn btn-primary' %>
+    <%= f.submit "Log in", class: 'btn btn-primary btn-lg w-100' %>
   </fieldset>
+
+  <div class="pt-3 text-center">
+    <a title="Forgot your password?" href="<%= new_password_path(resource_name) %>"
+      class="forgot">Forgot your password?</a>
+  </div>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,6 +13,9 @@
       <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
     </div>
 
+    <a title="Forgot your password?" href="<%= new_password_path(resource_name) %>"
+        class="forgot">Forgot your password?</a>
+
     <div>
       <% if devise_mapping.rememberable? -%>
         <div class="form-group">
@@ -26,9 +29,4 @@
 
     <%= f.submit "Log in", class: 'btn btn-primary btn-lg w-100' %>
   </fieldset>
-
-  <div class="pt-3 text-center">
-    <a title="Forgot your password?" href="<%= new_password_path(resource_name) %>"
-      class="forgot">Forgot your password?</a>
-  </div>
 <% end %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -10,7 +10,7 @@
   </head>
    <body>
     <div class="devise">
-      <div class="devise-form">
+      <div class="devise-form container">
         <% flash.each do |key, value| %>
           <div class="fade">
             <div class="<%= flash_class(key) %>" role="alert">


### PR DESCRIPTION
#116 Fix placement of remember me login box 

Now looks like this. ⬇️

![Screen Shot 2019-08-04 at 3 11 54 PM](https://user-images.githubusercontent.com/17777636/62428722-417ef880-b6ca-11e9-8f0c-0a0424379c3e.png)

The 100% width was what was making the checkbox jump around crazily when the window was resized, please double-check to make sure removing that won't break anything! 🙂