### PR TITLE
send an email when lockbox balance drops below $300

### DIFF
--- a/app/mailers/lockbox_action_mailer.rb
+++ b/app/mailers/lockbox_action_mailer.rb
@@ -2,7 +2,10 @@ class LockboxActionMailer < ApplicationMailer
   def add_cash_email
     @lockbox_partner = params[:lockbox_partner]
     @lockbox_action = params[:lockbox_action]
+
     email_addresses = @lockbox_partner.users.confirmed.pluck(:email)
+    return if email_addresses.empty?
+
     mail(to: email_addresses, subject: 'TODO add subject')
   end
 end

--- a/app/mailers/lockbox_partner_mailer.rb
+++ b/app/mailers/lockbox_partner_mailer.rb
@@ -1,0 +1,8 @@
+class LockboxPartnerMailer < ApplicationMailer
+  def low_balance_alert
+    return unless ENV['LOW_BALANCE_ALERT_EMAIL'].present?
+
+    @lockbox_partner = params[:lockbox_partner]
+    mail(to: ENV['LOW_BALANCE_ALERT_EMAIL'], subject: "[LOW LOCKBOX BALANCE] #{@lockbox_partner.name} needs cash")
+  end
+end

--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -5,6 +5,7 @@ class LockboxPartner < ApplicationRecord
   # Number of days since last reconciliation when clinic user will be prompted
   # to reconcile the lockbox. TODO make this configurable (issue #138)
   RECONCILIATION_INTERVAL = 30
+  MINIMUM_ACCEPTABLE_BALANCE = Money.new(30000)
 
   scope :active, -> { with_active_user.with_initial_cash }
   scope :with_active_user, -> { joins(:users).merge(User.confirmed) }
@@ -24,6 +25,10 @@ class LockboxPartner < ApplicationRecord
       end
       balance
     end
+  end
+
+  def low_balance?
+    balance < MINIMUM_ACCEPTABLE_BALANCE
   end
 
   def relevant_transactions_for_balance(exclude_pending: false)

--- a/app/views/lockbox_partner_mailer/low_balance_alert.html.erb
+++ b/app/views/lockbox_partner_mailer/low_balance_alert.html.erb
@@ -1,0 +1,14 @@
+<html>
+  <head></head>
+  <body>
+    <h1>Heads up!</h1>
+    <div>
+      The lockbox balance at <b><%= @lockbox_partner.name %></b> is at <b>$<%= @lockbox_partner.balance.to_s %></b> when taking into account all pending support requests. 
+    </div>
+
+    <div>
+      Please <%= link_to "add cash to this lockbox", new_lockbox_partner_add_cash_url(@lockbox_partner) %>
+    </div>
+  </body>
+</html>
+

--- a/app/views/lockbox_partner_mailer/low_balance_alert.text.erb
+++ b/app/views/lockbox_partner_mailer/low_balance_alert.text.erb
@@ -1,0 +1,3 @@
+Heads up! The lockbox balance at <%= @lockbox_partner.name %> is at $<%= @lockbox_partner.balance.to_s %> when taking into account all pending support requests. 
+
+Please add cash to the lockbox here: <%= new_lockbox_partner_add_cash_url(@lockbox_partner) %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,6 +33,7 @@ Rails.application.configure do
   config.active_storage.service = :test
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { :host => 'http://localhost:3000/' }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/lib/create_support_request.rb
+++ b/lib/create_support_request.rb
@@ -19,23 +19,25 @@ class CreateSupportRequest
   # ]
   input :params
 
+  attr_accessor :support_request
+
   def call
     ActiveRecord::Base.transaction do
-      support_req = SupportRequest.create(
+      self.support_request = SupportRequest.create(
         lockbox_partner_id: params[:lockbox_partner_id],
         client_ref_id: params[:client_ref_id],
         name_or_alias: params[:name_or_alias],
         user_id: params[:user_id]
       )
 
-      fail!(support_req.errors.full_messages.join(', ')) unless support_req.valid?
+      fail!(support_request.errors.full_messages.join(', ')) unless support_request.valid?
 
       lockbox_action = LockboxAction.create(
         eff_date: params[:lockbox_action][:eff_date],
         action_type: LockboxAction::SUPPORT_CLIENT,
         status: LockboxAction::PENDING,
         lockbox_partner_id: params[:lockbox_partner_id],
-        support_request: support_req
+        support_request: support_request
       )
 
       fail!(lockbox_action.errors.full_messages.join(', ')) unless lockbox_action.valid?
@@ -49,8 +51,14 @@ class CreateSupportRequest
           category:       item[:category]
         )
       end
-
-      support_req
     end
+
+    send_low_balance_alert if support_request.lockbox_partner.low_balance?
+
+    support_request
+  end
+
+  def send_low_balance_alert
+    LockboxPartnerMailer.with(lockbox_partner: support_request.lockbox_partner).low_balance_alert.deliver
   end
 end

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require './lib/create_support_request'
+require './lib/add_cash_to_lockbox'
 
 describe CreateSupportRequest do
   let(:mac_user) { FactoryBot.create(:user) }
@@ -30,5 +31,62 @@ describe CreateSupportRequest do
     result = CreateSupportRequest.call(params: params)
     expect(result).to be_success
     expect(result.value).to be_an_instance_of(SupportRequest)
+  end
+
+  describe "low balance alert" do
+    let(:low_balance_lockbox_partner) { FactoryBot.create(:lockbox_partner, :active) }
+    let(:low_balance_params) do
+      {
+        client_ref_id:      "1234",
+        name_or_alias:      "some name",
+        urgency_flag:       "urgent",
+        lockbox_partner_id: low_balance_lockbox_partner.id,
+        lockbox_action: {
+          eff_date:         Date.current,
+          lockbox_transactions: [
+            {
+              amount:       1,
+              category:     "gas"
+            }
+          ]
+        },
+        user_id:            mac_user.id,
+      }
+    end
+
+    before do
+      AddCashToLockbox.call(lockbox_partner: low_balance_lockbox_partner, eff_date: 1.day.ago, amount: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE)
+    end
+
+    it 'goes to the finance team when balance is below $300' do
+      ENV['LOW_BALANCE_ALERT_EMAIL'] ||= 'lowbalance@alert.com'
+
+      result = CreateSupportRequest.call(params: low_balance_params)
+      expected_dollar_value = (LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE - Money.new(100)).to_s
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail).to be_present
+      expect(mail.to).to include ENV['LOW_BALANCE_ALERT_EMAIL']
+
+      expect(mail.parts.detect{|p| p.mime_type == "text/plain"}.body.raw_source).to include expected_dollar_value
+      expect(mail.parts.detect{|p| p.mime_type == "text/html"}.body.raw_source).to include expected_dollar_value
+    end
+
+    it "doesn't blow up when email is missing" do
+      ENV['LOW_BALANCE_ALERT_EMAIL'] = nil
+
+      expect { CreateSupportRequest.call(params: low_balance_params) }
+        .not_to change{ActionMailer::Base.deliveries.length}
+    end
+
+    it 'is not sent when the balance remains above $300' do
+      ENV['LOW_BALANCE_ALERT_EMAIL'] ||= 'lowbalance@alert.com'
+
+      AddCashToLockbox.call(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE + Money.new(15000))
+
+      params[:lockbox_action][:lockbox_transactions][0][:amount] = 100
+      expect { CreateSupportRequest.call(params: params) }
+        .not_to change{ActionMailer::Base.deliveries.length}
+    end
   end
 end

--- a/spec/models/lockbox_partner_spec.rb
+++ b/spec/models/lockbox_partner_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require './lib/add_cash_to_lockbox'
 
 describe LockboxPartner, type: :model do
   it { is_expected.to have_many(:users) }
@@ -328,6 +329,19 @@ describe LockboxPartner, type: :model do
       let(:lockbox_partner) { build(:lockbox_partner) }
 
       it { is_expected.to be false }
+    end
+  end
+
+  describe 'low_balance?' do
+    it 'is true when the balance is below $300' do
+      lockbox_partner = FactoryBot.create(:lockbox_partner)
+      
+      low_amount = LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE - Money.new(100)
+      AddCashToLockbox.call(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: low_amount)
+      expect(lockbox_partner).to be_low_balance
+
+      AddCashToLockbox.call(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: Money.new(100))
+      expect(lockbox_partner).not_to be_low_balance
     end
   end
 end


### PR DESCRIPTION
## Changelog
- Mailer for low balance alerts
- `low_balance?` method on `LockboxPartner`
- Hook to send the email when a `SupportRequest` brings the balance below the threshold

## Link to issue:  
Fixes issue #28 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
Example email:
<img width="769" alt="_LOW_LOCKBOX_BALANCE__Owl_Health_Associates_needs_cash" src="https://user-images.githubusercontent.com/608232/63660621-ce264f00-c77c-11e9-8e8f-d461450a5c8d.png">

## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots

## Deploy

Requires setting the `LOW_BALANCE_ALERT_EMAIL` env var