### PR TITLE
support requests index view

### DIFF
--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -1,3 +1,12 @@
+#support-requests-index {
+  max-width: 600px;
+  margin: 0 auto;
+
+  h2 {
+    margin: 30px auto;
+  }
+}
+
 .support-request-header {
   margin: 30px auto;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+
+  def require_admin
+    unless current_user.admin?
+      flash[:error] = "You are not authorized to access this page"
+      return redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/support_requests_controller.rb
+++ b/app/controllers/support_requests_controller.rb
@@ -2,6 +2,12 @@ require './lib/create_support_request'
 
 class SupportRequestsController < ApplicationController
 
+  before_action :require_admin, except: [:create]
+
+  def index
+    @support_requests = SupportRequest.pending.order("created_at desc")
+  end
+
   def create
     result = CreateSupportRequest.call(params: all_support_request_params)
     if result.success?

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,3 +11,4 @@ require('bootstrap');
 require('../src/alerts');
 require('../src/transactions');
 require('../src/notes');
+require('../src/url_switching_select');

--- a/app/javascript/src/url_switching_select.js
+++ b/app/javascript/src/url_switching_select.js
@@ -1,0 +1,5 @@
+document.addEventListener('turbolinks:load', () => {
+  $(".url-switcher").on('change', function(){
+    window.location = this.value;
+  });
+});

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -12,6 +12,10 @@ class SupportRequest < ApplicationRecord
   # Sometimes the UUID will already have been created elsewhere, and sometimes not
   before_validation :populate_client_ref_id
 
+  # for greppability:
+  # scope :pending
+  # scope :completed
+  # scope :canceled
   LockboxAction::STATUSES.each do |status|
     scope status, -> { joins(:lockbox_action).where("lockbox_actions.status": status) }
     scope "#{status}_for_partner", ->(lockbox_partner_id:) { joins(:lockbox_action).where(lockbox_partner_id: lockbox_partner_id, "lockbox_actions.status": status) }

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -12,10 +12,9 @@ class SupportRequest < ApplicationRecord
   # Sometimes the UUID will already have been created elsewhere, and sometimes not
   before_validation :populate_client_ref_id
 
-  def self.pending_for_partner(lockbox_partner_id:)
-    LockboxAction.where.not(support_request_id: nil)
-      .where(lockbox_partner_id: lockbox_partner_id, status: LockboxAction::PENDING)
-      .map(&:support_request)
+  LockboxAction::STATUSES.each do |status|
+    scope status, -> { joins(:lockbox_action).where("lockbox_actions.status": status) }
+    scope "#{status}_for_partner", ->(lockbox_partner_id:) { joins(:lockbox_action).where(lockbox_partner_id: lockbox_partner_id, "lockbox_actions.status": status) }
   end
 
   def status

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-    <% if current_user.partner? %>
+  <% if current_user.partner? %>
     <%= render partial: 'dashboard/lockbox_partner', object: @lockbox_partner, as: :lockbox_partner %>
   <% else %>
     <div id="dashboard-lockbox-partners">
@@ -7,7 +7,13 @@
       <%= link_to 'File a support request', support_requests_new_path, class: 'btn btn-primary view-half' %>
       <%= link_to 'Create new lockbox partner', new_lockbox_partner_path, class: 'btn btn-secondary view-half float-right' %>
       <div class="horizontal-rule"></div>
-      <p><strong>Current View:</strong>  Lockbox Partners (<%= @lockbox_partners.count %>)</p>
+      <p>
+        <strong>Current View:</strong>  
+        <%= render 'shared/url_switching_select', options: [
+          ['Lockbox Partners', root_path],
+          ['Pending Support Requests', support_requests_path]
+        ], selected_value: root_path %>
+      </p>
       <%= render partial: 'dashboard/admin_dash', collection: @lockbox_partners, as: :lockbox_partner%>
     </div>
   <% end %>

--- a/app/views/shared/_url_switching_select.html.erb
+++ b/app/views/shared/_url_switching_select.html.erb
@@ -1,0 +1,4 @@
+<select class="url-switcher">
+  <%= options_for_select options, selected_value %>
+</select>
+

--- a/app/views/support_requests/index.html.erb
+++ b/app/views/support_requests/index.html.erb
@@ -1,0 +1,41 @@
+<div class="container">
+  <div id="support-requests-index">
+    <h2>Welcome, <%= current_user.name %>!</h2>
+    <%= link_to 'File a support request', support_requests_new_path, class: 'btn btn-primary view-half' %>
+      <%= link_to 'Create new lockbox partner', new_lockbox_partner_path, class: 'btn btn-secondary view-half float-right' %>
+    <div class="horizontal-rule"></div>
+    <p>
+    <strong>Current View:</strong> 
+    <%= render 'shared/url_switching_select', options: [
+      ['Lockbox Partners', root_path],
+      ['Pending Support Requests', support_requests_path]
+    ], selected_value: support_requests_path %>
+    </p>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Status</th>
+          <th>Amount</th>
+          <th>Partner</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @support_requests.each do |support_request| %>
+          <tr>
+            <td><%= support_request.created_at.to_date %></td>
+            <td><%= support_request.status.capitalize %></td>
+            <td>$<%= support_request.amount.to_s %></td>
+            <td><%= support_request.lockbox_partner.name %></td>
+            <td>
+              <%= link_to [support_request.lockbox_partner, support_request] do %>
+                View Details <i class="fa fa-long-arrow-right" aria-hidden="true"></i>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get 'onboarding_success', to: 'dashboard#onboarding_success'
 
   match 'support_requests/new', to: 'lockbox_partners/support_requests#new', via: [:get]
-  resource :support_requests, only: [:create]
+  resources :support_requests, only: [:index, :create]
 
   resources :lockbox_partners, only: [:new, :create, :show] do
     scope module: 'lockbox_partners' do

--- a/spec/controllers/support_requests_controller_spec.rb
+++ b/spec/controllers/support_requests_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe SupportRequestsController do
+
+  describe "#index" do
+    context "when the user is an admin" do
+      it "returns 200" do
+        user = create(:user, role: User::ADMIN)
+        sign_in(user)
+        get :index
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when the user is not an admin" do
+      it "returns 302" do
+        user = create(:user, role: User::PARTNER)
+        sign_in(user)
+        get :index
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end
+

--- a/spec/factories/support_requests.rb
+++ b/spec/factories/support_requests.rb
@@ -5,4 +5,16 @@ FactoryBot.define do
     name_or_alias  { Faker::Name.first_name }
     client_ref_id  { Faker::Alphanumeric.alpha(8) }
   end
+
+  trait(:pending) do
+    lockbox_action { build(:lockbox_action) }
+  end
+
+  trait(:completed) do
+    lockbox_action { build(:lockbox_action, :completed) }
+  end
+
+  trait(:canceled) do
+    lockbox_action { build(:lockbox_action, :canceled) }
+  end
 end

--- a/spec/models/support_request_spec.rb
+++ b/spec/models/support_request_spec.rb
@@ -11,59 +11,91 @@ describe SupportRequest, type: :model do
   it { is_expected.to validate_presence_of(:user) }
   it { is_expected.to validate_presence_of(:lockbox_partner) }
 
-  describe '.pending_for_lockbox' do
-    def create_support_requests(partner, n)
-      [].tap do |arr|
-        n.times do
-          req = CreateSupportRequest.call!(
-            params: {
-              lockbox_partner_id: partner.id,
-              name_or_alias: Faker::Name.name,
-              user_id: user.id,
-              client_ref_id: 'somestring',
-              lockbox_action: {
-                eff_date: Date.current,
-                lockbox_transactions: [
-                  {
-                    amount: Money.new(12345),
-                    category: LockboxTransaction::EXPENSE_CATEGORIES.sample
-                  }
-                ]
-              }
-            }
-          )
+  describe 'status scopes' do
+    let!(:pending_request) { FactoryBot.create(:support_request, :pending) }
+    let!(:completed_request) { FactoryBot.create(:support_request, :completed) }
+    let!(:canceled_request) { FactoryBot.create(:support_request, :canceled) }
 
-          arr << req
-        end
-      end
+    it 'returns only pending support requests' do
+      results = SupportRequest.pending
+
+      expect(results).to     include(pending_request)
+      expect(results).not_to include(completed_request)
+      expect(results).not_to include(canceled_request)
     end
 
-    let(:user)              { FactoryBot.create(:user) }
-    let(:lockbox_partner_1) { FactoryBot.create(:lockbox_partner, :active) }
-    let(:lockbox_partner_2) { FactoryBot.create(:lockbox_partner, :active) }
+    it 'returns only completed support requests' do
+      results = SupportRequest.completed
 
-    let(:correct_partner_wrong_status) do
-      create_support_requests(lockbox_partner_1, 2).tap do |support_reqs|
-        support_reqs.first.lockbox_action.complete!
-        support_reqs.last.lockbox_action.cancel!
-      end
+      expect(results).not_to include(pending_request)
+      expect(results).to     include(completed_request)
+      expect(results).not_to include(canceled_request)
     end
 
-    let(:wrong_partner_correct_status) do
-      create_support_requests(lockbox_partner_2, 1)
+    it 'returns only canceled support requests' do
+      results = SupportRequest.canceled
+
+      expect(results).not_to include(pending_request)
+      expect(results).not_to include(completed_request)
+      expect(results).to     include(canceled_request)
+    end
+  end
+
+  describe 'partner status scopes' do
+    let!(:pending_wrong_partner) { FactoryBot.create(:support_request, :pending) }
+    let!(:completed_wrong_partner) { FactoryBot.create(:support_request, :completed) }
+    let!(:canceled_wrong_partner) { FactoryBot.create(:support_request, :canceled) }
+    let!(:pending_right_partner) { FactoryBot.create(:support_request, :pending) }
+    let!(:completed_right_partner) { FactoryBot.create(:support_request, :completed) }
+    let!(:canceled_right_partner) { FactoryBot.create(:support_request, :canceled) }
+
+    let(:right_partner) { FactoryBot.create(:lockbox_partner) }
+    let(:wrong_partner) { FactoryBot.create(:lockbox_partner) }
+
+    before do
+      pending_wrong_partner.update(lockbox_partner: wrong_partner)
+      completed_wrong_partner.update(lockbox_partner: wrong_partner)
+      canceled_wrong_partner.update(lockbox_partner: wrong_partner)
+
+      pending_right_partner.update(lockbox_partner: right_partner)
+      completed_right_partner.update(lockbox_partner: right_partner)
+      canceled_right_partner.update(lockbox_partner: right_partner)
     end
 
-    let!(:expected_returned) do
-      create_support_requests(lockbox_partner_1, 2)
+    it 'returns only pending support requests' do
+      results = SupportRequest.pending_for_partner(lockbox_partner_id: right_partner.id)
+
+      expect(results).to     include(pending_right_partner)
+      expect(results).not_to include(completed_right_partner)
+      expect(results).not_to include(canceled_right_partner)
+
+      expect(results).not_to include(pending_wrong_partner)
+      expect(results).not_to include(completed_wrong_partner)
+      expect(results).not_to include(canceled_wrong_partner)
     end
 
-    let!(:not_expected_returned) do
-      correct_partner_wrong_status + wrong_partner_correct_status
+    it 'returns only completed support requests' do
+      results = SupportRequest.completed_for_partner(lockbox_partner_id: right_partner.id)
+
+      expect(results).not_to include(pending_right_partner)
+      expect(results).to     include(completed_right_partner)
+      expect(results).not_to include(canceled_right_partner)
+
+      expect(results).not_to include(pending_wrong_partner)
+      expect(results).not_to include(completed_wrong_partner)
+      expect(results).not_to include(canceled_wrong_partner)
     end
 
-    it "returns only pending status support_requests for a given partner" do
-      result = described_class.pending_for_partner(lockbox_partner_id: lockbox_partner_1.id)
-      expect(result).to match(expected_returned)
+    it 'returns only canceled support requests' do
+      results = SupportRequest.canceled_for_partner(lockbox_partner_id: right_partner.id)
+
+      expect(results).not_to include(pending_right_partner)
+      expect(results).not_to include(completed_right_partner)
+      expect(results).to     include(canceled_right_partner)
+
+      expect(results).not_to include(pending_wrong_partner)
+      expect(results).not_to include(completed_wrong_partner)
+      expect(results).not_to include(canceled_wrong_partner)
     end
   end
 end


### PR DESCRIPTION
## Changelog
- status scopes on support request
- support requests index page
- dropdown to switch between pages\

## Link to issue:  
Fixes issue #155 

## Steps for QA/Special Notes:
- view should only be available for admins

## Relevant Screenshots: 
New view at `/support_requests`

<img width="945" alt="LockboxRails" src="https://user-images.githubusercontent.com/608232/63831493-6286e200-c934-11e9-9264-09ddf35ad344.png">


## Caveats

- I'm not sure this select-based nav is going to be very extensible, pretty soon we're going to want to filter within the support requests index instead of switching to a new URL.
- I'm not sure if there are any other mocks with implications on this select either.
- No limit on the number of support requests we show.  Probably fine for quite a while, but if this starts timing out we'll need to paginate.
- I didn't include a count in the dropdown... I've found counts in nav items to be frustrating over time.
- Also I used a select instead of a link, I'm not sure how closely we're trying to hit these mocks
- Flash messages aren't showing up

## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
