### PR TITLE
Add support request status update dropdown

### DIFF
--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -19,6 +19,10 @@
     margin-right: 20px;
     width: 25%;
   }
+  .dropdown-toggle {
+    margin: 0;
+    width: 160px;
+  }
   .row {
     div {
       p {

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,5 @@
 class DashboardController < ApplicationController
   def index
-    flash[:notice] = "This is a test"
     if current_user.partner?
       @lockbox_partner = current_user.lockbox_partner
     else

--- a/app/controllers/lockbox_partners/support_requests_controller.rb
+++ b/app/controllers/lockbox_partners/support_requests_controller.rb
@@ -29,6 +29,18 @@ class LockboxPartners::SupportRequestsController < ApplicationController
     @lockbox_partner = @support_request.lockbox_partner
   end
 
+  def update_status
+    @support_request = SupportRequest.find(params[:support_request_id])
+    @lockbox_partner = @support_request.lockbox_partner
+    status = update_status_params[:status]
+    if @support_request.lockbox_action.update(status: status)
+      flash[:notice] = "Status updated to #{status}"
+    else
+      flash[:error] = "Failed to update status"
+    end
+    redirect_to lockbox_partner_support_request_path(id: @support_request.id)
+  end
+
   private
 
   def all_support_request_params
@@ -45,6 +57,10 @@ class LockboxPartners::SupportRequestsController < ApplicationController
       :urgency_flag,
       :lockbox_partner_id
     )
+  end
+
+  def update_status_params
+    params.permit(:status)
   end
 
   def lockbox_action_params

--- a/app/controllers/lockbox_partners/support_requests_controller.rb
+++ b/app/controllers/lockbox_partners/support_requests_controller.rb
@@ -31,7 +31,6 @@ class LockboxPartners::SupportRequestsController < ApplicationController
 
   def update_status
     @support_request = SupportRequest.find(params[:support_request_id])
-    @lockbox_partner = @support_request.lockbox_partner
     status = update_status_params[:status]
     if @support_request.lockbox_action.update(status: status)
       flash[:notice] = "Status updated to #{status}"

--- a/app/controllers/lockbox_partners/support_requests_controller.rb
+++ b/app/controllers/lockbox_partners/support_requests_controller.rb
@@ -37,7 +37,7 @@ class LockboxPartners::SupportRequestsController < ApplicationController
     else
       flash[:error] = "Failed to update status"
     end
-    redirect_to lockbox_partner_support_request_path(id: @support_request.id)
+    redirect_back(fallback_location: lockbox_partner_support_request_path(id: @support_request.id))
   end
 
   private

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -37,6 +37,16 @@ class SupportRequest < ApplicationRecord
     @most_recent_note ||= notes.last
   end
 
+  def status_options
+    LockboxAction::STATUSES - [status]
+  end
+
+  def update_status_path(params)
+    params = { lockbox_partner_id: lockbox_partner_id, support_request_id: id }.merge(params)
+    Rails.application.routes.url_helpers
+      .lockbox_partner_support_request_update_status_path(params)
+  end
+
   private
 
   def populate_client_ref_id

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -41,12 +41,6 @@ class SupportRequest < ApplicationRecord
     LockboxAction::STATUSES - [status]
   end
 
-  def update_status_path(params)
-    params = { lockbox_partner_id: lockbox_partner_id, support_request_id: id }.merge(params)
-    Rails.application.routes.url_helpers
-      .lockbox_partner_support_request_update_status_path(params)
-  end
-
   private
 
   def populate_client_ref_id

--- a/app/views/lockbox_partners/support_requests/_details_admin.html.erb
+++ b/app/views/lockbox_partners/support_requests/_details_admin.html.erb
@@ -1,5 +1,6 @@
 <div class="support-request-header">
-  <h3>Support Request for <%= @support_request.name_or_alias %> <span class="float-right"><%= @support_request.status %></span></h3>
+  <%= render partial: 'status_dropdown', locals: { support_request: @support_request, label: false } %>
+  <h3>Support Request for <%= @support_request.name_or_alias %></h3>
   <%= render partial: 'flag', locals: { support_request: @support_request } %>
 </div>
 <div class="row">

--- a/app/views/lockbox_partners/support_requests/_details_partner.html.erb
+++ b/app/views/lockbox_partners/support_requests/_details_partner.html.erb
@@ -1,5 +1,6 @@
 <div class="support-request-header">
   <p><b><%= @support_request.pickup_date %> - <%= @support_request.name_or_alias %> - <%= @support_request&.client_ref_id %></b></p>
-  <h3>Support Request:  $<%= @support_request.amount %> <span class="float-right"><%= @support_request.status %></span></h3>
+  <%= render partial: 'status_dropdown', locals: { support_request: @support_request, label: false } %>
+  <h3>Support Request:  $<%= @support_request.amount %></h3>
   <%= render partial: 'flag', locals: { support_request: @support_request } %>
 </div>

--- a/app/views/lockbox_partners/support_requests/_pending.html.erb
+++ b/app/views/lockbox_partners/support_requests/_pending.html.erb
@@ -1,10 +1,7 @@
 <div class="pending-request">
   <div class="header">
     <div class="content">
-      <div class="float-right">
-        <p>Update Status</p>
-        <a class="btn btn-primary btn-large"><%= support_request.status %> <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
-      </div>
+      <%= render partial: 'lockbox_partners/support_requests/status_dropdown', locals: { support_request: support_request, label: true } %>
       <p><b><%= support_request.pickup_date %> - <%= support_request.name_or_alias %></b></p>
       <h3>Support Request:  $<%= support_request.amount %></h3>
     </div>

--- a/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
@@ -1,0 +1,14 @@
+<div class="dropdown float-right">
+  <% if label %>
+    <p>Update Status</p>
+  <% end %>
+  <a class="btn btn-primary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <%= support_request.status.capitalize %>
+  </a>
+  <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+    <% support_request.status_options.each do |option| %>
+      <%= link_to option.capitalize, support_request.update_status_path(status: option),
+        class: 'dropdown-item', method: 'post' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
@@ -13,7 +13,7 @@
           lockbox_partner_id: support_request.lockbox_partner_id,
           status: option
         ),
-        class: 'dropdown-item', method: 'post' %>
+        class: 'dropdown-item', method: 'post', remote: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
@@ -7,7 +7,12 @@
   </a>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
     <% support_request.status_options.each do |option| %>
-      <%= link_to option.capitalize, support_request.update_status_path(status: option),
+      <%= link_to option.capitalize,
+        lockbox_partner_support_request_update_status_path(
+          support_request_id: support_request.id,
+          lockbox_partner_id: support_request.lockbox_partner_id,
+          status: option
+        ),
         class: 'dropdown-item', method: 'post' %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     scope module: 'lockbox_partners' do
       resources :users, only: [:new, :create]
       resources :support_requests, only: [:new, :create, :show] do
+        post 'update_status', to: 'support_requests#update_status', as: 'update_status'
         resources :notes, only: [:create]
       end
       resource :add_cash, only: [:new, :create], controller: 'add_cash'

--- a/spec/controllers/lockbox_partners/support_requests_controller_spec.rb
+++ b/spec/controllers/lockbox_partners/support_requests_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe LockboxPartners::SupportRequestsController do
+  let(:support_request) { create(:support_request, :pending) }
+  let(:user) { create(:user, role: User::PARTNER, lockbox_partner: support_request.lockbox_partner) }
+
+  describe "#update_status" do
+    it 'updates the status of the lockbox action associated with the support request' do
+      sign_in(user)
+      post :update_status, params: {
+        lockbox_partner_id: support_request.lockbox_partner_id,
+        support_request_id: support_request.id,
+        status: 'completed'
+      }
+      expect(support_request.lockbox_action.reload.status).to eq 'completed'
+    end
+  end
+end


### PR DESCRIPTION
## Changelog
* Added a status update dropdown to the lockbox_partner/support_request#show page
* Duplicated dropdown to the pending support request partial in action needed view

## Link to issue:  
#29 

## Relevant Screenshots: 
<img width="597" alt="Screen Shot 2019-09-01 at 3 11 09 PM" src="https://user-images.githubusercontent.com/4739591/64081746-c7429380-ccca-11e9-9023-b701a4d49b50.png">
<img width="549" alt="Screen Shot 2019-09-01 at 3 11 21 PM" src="https://user-images.githubusercontent.com/4739591/64081747-c90c5700-ccca-11e9-8aad-b2c578531270.png">

Note, because these dropdowns are shared between two views, both redirect to the support request show page when completed. If this is not the desired ux it can be easily changed
