### PR TITLE
partners can confirm deposit

### DIFF
--- a/app/controllers/lockbox_actions_controller.rb
+++ b/app/controllers/lockbox_actions_controller.rb
@@ -1,0 +1,23 @@
+class LockboxActionsController < ApplicationController
+  before_action :find_lockbox_action, only: [:update]
+
+  def update
+    if @lockbox_action.update(update_params)
+      flash[:notice] = "Success!"
+      redirect_to lockbox_partners_path
+    else
+      flash[:error] = "Sorry, there was a problem."
+      redirect_to lockbox_partners_path
+    end
+  end
+
+  private
+
+  def find_lockbox_action
+    @lockbox_action = LockboxAction.find(params[:id])
+  end
+
+  def update_params
+    params.require(:lockbox_action).permit(:status)
+  end
+end

--- a/app/controllers/lockbox_actions_controller.rb
+++ b/app/controllers/lockbox_actions_controller.rb
@@ -1,5 +1,6 @@
 class LockboxActionsController < ApplicationController
   before_action :find_lockbox_action, only: [:update]
+  before_action :require_ownership
 
   def update
     if @lockbox_action.update(update_params)
@@ -19,5 +20,11 @@ class LockboxActionsController < ApplicationController
 
   def update_params
     params.require(:lockbox_action).permit(:status)
+  end
+
+  def require_ownership
+    if !current_user.admin? && current_user.lockbox_partner != @lockbox_action.lockbox_partner
+      return redirect_to root_path
+    end
   end
 end

--- a/app/controllers/lockbox_actions_controller.rb
+++ b/app/controllers/lockbox_actions_controller.rb
@@ -7,7 +7,7 @@ class LockboxActionsController < ApplicationController
       flash[:notice] = "Success!"
       redirect_to lockbox_partners_path
     else
-      flash[:error] = "Sorry, there was a problem."
+      flash[:alert] = "Sorry, there was a problem."
       redirect_to lockbox_partners_path
     end
   end

--- a/app/models/lockbox_action.rb
+++ b/app/models/lockbox_action.rb
@@ -58,7 +58,7 @@ class LockboxAction < ApplicationRecord
           balance_effect = if expected_amount > params[:amount_cents]
             LockboxTransaction::DEBIT
           else
-           LockboxTransaction::CREDIT
+            LockboxTransaction::CREDIT
           end
 
           lockbox_action.lockbox_transactions.create!(

--- a/app/models/lockbox_action.rb
+++ b/app/models/lockbox_action.rb
@@ -29,9 +29,8 @@ class LockboxAction < ApplicationRecord
 
   scope :excluding_statuses, -> (*statuses) { where.not(status: statuses) }
 
-  scope :completed_cash_additions, -> do
-    where(status: COMPLETED, action_type: ADD_CASH)
-  end
+  scope :pending_cash_additions,   -> { where(status: PENDING,   action_type: ADD_CASH) }
+  scope :completed_cash_additions, -> { where(status: COMPLETED, action_type: ADD_CASH) }
 
   # action_type should correspond with ACTION_TYPES
   def self.create_with_transactions(action_type, params)
@@ -59,7 +58,7 @@ class LockboxAction < ApplicationRecord
           balance_effect = if expected_amount > params[:amount_cents]
             LockboxTransaction::DEBIT
           else
-            LockboxTransaction::CREDIT
+           LockboxTransaction::CREDIT
           end
 
           lockbox_action.lockbox_transactions.create!(

--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -35,6 +35,10 @@ class LockboxPartner < ApplicationRecord
     balance < MINIMUM_ACCEPTABLE_BALANCE
   end
 
+  def awaiting_infusion?
+    lockbox_actions.pending_cash_additions.any?
+  end
+
   def relevant_transactions_for_balance(exclude_pending: false)
     excluded_statuses = [ LockboxAction::CANCELED ]
     excluded_statuses << LockboxAction::PENDING if exclude_pending

--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -35,7 +35,7 @@ class LockboxPartner < ApplicationRecord
     balance < MINIMUM_ACCEPTABLE_BALANCE
   end
 
-  def awaiting_infusion?
+  def cash_addition_confirmation_pending?
     lockbox_actions.pending_cash_additions.any?
   end
 

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -8,7 +8,24 @@
       <div>It's been <%= days_since_last_reconciliation %> days since the lockbox has been reconciled. Please count the cash in the box and record the total.</div>
     </div>
     <div class="p-2">
-      <%= link_to "Reconcile budget", new_lockbox_partner_reconciliation_path(lockbox_partner), class: 'btn btn-danger' %>
+      <%= link_to "Reconcile Budget", new_lockbox_partner_reconciliation_path(lockbox_partner), class: 'btn btn-danger' %>
     </div>
   </div>
+<% end %>
+
+<% if lockbox_partner.awaiting_infusion? %>
+  <% lockbox_partner.lockbox_actions.pending_cash_additions.each do |cash_action| %>
+    <div class="alert alert-warning d-flex">
+      <div class="p-2">
+        <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
+      </div>
+      <div class="p-2 flex-grow-1">
+        <h4 class="alert-heading">Cash Sent</h4>
+        <div>A $<%= cash_action.amount %> check was mailed on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.</div>
+      </div>
+      <div class="p-2">
+        <%= link_to "Confirm Cash Addition", lockbox_action_path(cash_action, {lockbox_action: {status: :complete}}), method: :put, class: 'btn btn-warning' %>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -13,7 +13,7 @@
   </div>
 <% end %>
 
-<% if lockbox_partner.awaiting_infusion? %>
+<% if lockbox_partner.cash_addition_confirmation_pending? %>
   <% lockbox_partner.lockbox_actions.pending_cash_additions.each do |cash_action| %>
     <div class="alert alert-warning d-flex">
       <div class="p-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,6 @@ Rails.application.routes.draw do
       resource :reconciliation, only: [:new, :create], controller: 'reconciliation'
     end
   end
+
+  resources :lockbox_actions
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,5 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :lockbox_actions
+  resources :lockbox_actions, only: [:update]
 end

--- a/spec/controllers/lockbox_actions_controller_spec.rb
+++ b/spec/controllers/lockbox_actions_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe LockboxActionsController do
+  let(:authorized_lockbox_partner) { create(:lockbox_partner, :active) }
+  let(:unauthorized_lockbox_partner) { create(:lockbox_partner, :active) }
+
+  let(:lockbox_action) { create(:lockbox_action, lockbox_partner: authorized_lockbox_partner, status: :pending) }
+
+  let(:user) { create(:user, role: user_role, lockbox_partner: user_lockbox_partner) }
+
+  describe "#update" do
+    before do
+      sign_in(user)
+      put :update, params: {id: lockbox_action.id, lockbox_action: {status: LockboxAction::COMPLETED}}
+    end
+
+    context "when the user is an admin" do
+      let(:user_role) { User::ADMIN }
+      let(:user_lockbox_partner) { nil }
+
+      it "updates the lockbox action" do
+        expect(lockbox_action.reload.status).to eq(LockboxAction::COMPLETED)
+      end
+    end
+
+    context "when the user belongs to the correct partner" do
+      let(:user_role) { User::PARTNER }
+      let(:user_lockbox_partner) { authorized_lockbox_partner }
+
+      it "updates the lockbox action" do
+        expect(lockbox_action.reload.status).to eq(LockboxAction::COMPLETED)
+      end
+    end
+
+    context "when the user does not belong to the correct partner" do
+      let(:user_role) { User::PARTNER }
+      let(:user_lockbox_partner) { unauthorized_lockbox_partner }
+
+      it "does not update the lockbox action" do
+        expect(lockbox_action.reload.status).to eq(LockboxAction::PENDING)
+      end
+    end
+  end
+end
+

--- a/spec/models/lockbox_partner_spec.rb
+++ b/spec/models/lockbox_partner_spec.rb
@@ -5,6 +5,23 @@ describe LockboxPartner, type: :model do
   it { is_expected.to have_many(:users) }
   it { is_expected.to have_many(:lockbox_actions) }
 
+  describe '#awaiting_infusion?' do
+    it "is true if the partner has a pending cash addition" do
+      lp = FactoryBot.create(:lockbox_partner)
+      expect(lp).not_to be_awaiting_infusion
+
+      AddCashToLockbox.call(lockbox_partner: lp, eff_date: Date.today, amount: 100)
+
+      expect(lp).to be_awaiting_infusion
+
+      lp.lockbox_actions.pending_cash_additions.each do |la|
+        la.complete!
+      end
+
+      expect(lp).not_to be_awaiting_infusion
+    end
+  end
+
   describe '#balance' do
     let(:lockbox) { FactoryBot.create(:lockbox_partner) }
 

--- a/spec/models/lockbox_partner_spec.rb
+++ b/spec/models/lockbox_partner_spec.rb
@@ -5,20 +5,20 @@ describe LockboxPartner, type: :model do
   it { is_expected.to have_many(:users) }
   it { is_expected.to have_many(:lockbox_actions) }
 
-  describe '#awaiting_infusion?' do
+  describe '#cash_addition_confirmation_pending?' do
     it "is true if the partner has a pending cash addition" do
       lp = FactoryBot.create(:lockbox_partner)
-      expect(lp).not_to be_awaiting_infusion
+      expect(lp).not_to be_cash_addition_confirmation_pending
 
       AddCashToLockbox.call(lockbox_partner: lp, eff_date: Date.today, amount: 100)
 
-      expect(lp).to be_awaiting_infusion
+      expect(lp).to be_cash_addition_confirmation_pending
 
       lp.lockbox_actions.pending_cash_additions.each do |la|
         la.complete!
       end
 
-      expect(lp).not_to be_awaiting_infusion
+      expect(lp).not_to be_cash_addition_confirmation_pending
     end
   end
 


### PR DESCRIPTION
Ability for partners to see that cash is on the way, and confirm they received it.

## Changelog
- New controller for working with LockboxActions
- New predicate method `LockboxPartner#awaiting_infusion?`
- New alert for partners

## Link to issue:  
Fixes issue #184 


## Steps for QA/Special Notes:
- N/A

## Open Questions

- [ ] Is `eff_date` the date the money was sent?
- [ ] Are all infusions checks?

## Relevant Screenshots: 

Normally you'd only have one of these, but they'll stack up until they're confirmed.

<img width="1277" alt="alerts" src="https://user-images.githubusercontent.com/608232/64496701-a996a080-d26d-11e9-8df9-bd4f7965a969.png">



## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
