### PR TITLE
Persist header in all tabs of lockbox partner, fix seeds file, add ad…

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,3 +31,4 @@
 @import 'support_request';
 @import 'notes';
 @import 'alert';
+@import 'lockbox_partners';

--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -34,10 +34,8 @@ a {
 
 .table {
   margin-top: 20px;
-  border-top: solid 2px black;
   thead {
     background-color: #dee2e6;
-    border-top: solid 2px black;
   }
 }
 

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -50,6 +50,9 @@
 
     .lockbox-activity {
       margin-bottom: 50px;
+      .table {
+        border-top: solid 2px black;
+      }
     }
 
     .view-full {
@@ -146,11 +149,6 @@
 
 hr {
   border-width: 2px;
-}
-
-.lockbox-partner-header {
-  margin: 0px auto;
-  margin-top: 50px;
 }
 
 .header-separator {

--- a/app/assets/stylesheets/lockbox_partners.scss
+++ b/app/assets/stylesheets/lockbox_partners.scss
@@ -1,0 +1,25 @@
+.lockbox-partner-header {
+  margin: 0px auto;
+  margin-top: 50px;
+  border-bottom: solid 2px black;
+
+  .lockbox-partner-info {
+    p {
+      width: 300px;
+      vertical-align: top;
+      display: inline-block;
+    }
+  }
+}
+
+.lockbox-activity {
+  table {
+    margin-top: 0;
+  }
+}
+
+.add-cash-form,
+.new-user-form {
+  padding: 20px;
+}
+

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -14,6 +14,7 @@
 .support-request-container {
   color: black;
   margin: 10px auto;
+  margin-top: 0;
   .btn {
     margin: 20px auto;
     margin-right: 20px;

--- a/app/views/lockbox_partners/_header.html.erb
+++ b/app/views/lockbox_partners/_header.html.erb
@@ -4,4 +4,11 @@
     <%= link_to 'Back to dashboard', lockbox_partners_path, class: 'float-right' %>
   <% end %>
   <h2><%= lockbox_partner.name %> <span class="float-right"><%= lockbox_partner.balance %></span></h2>
+  <div class="lockbox-partner-info">
+    <p class="address">
+      <%= lockbox_partner.street_address %></br>
+      <%= lockbox_partner.city %>, <%= lockbox_partner.state %> <%= lockbox_partner.zip_code %>
+    </p>
+    <p class="phone_number"><%= lockbox_partner.phone_number %></p>
+  </div>
 </div>

--- a/app/views/lockbox_partners/add_cash/new.html.erb
+++ b/app/views/lockbox_partners/add_cash/new.html.erb
@@ -1,5 +1,6 @@
 <div class="container">
-  <%= form_for :add_cash, class: "form", url: lockbox_partner_add_cash_path do |f| %>
+  <%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
+  <%= form_for :add_cash, html: { class: "form add-cash-form" }, url: lockbox_partner_add_cash_path do |f| %>
     <h2>Add Cash to Lockbox</h2>
     <p>Complete this form when you have put the check in the mail</p>
     <div class="form-group">

--- a/app/views/lockbox_partners/support_requests/new.html.erb
+++ b/app/views/lockbox_partners/support_requests/new.html.erb
@@ -1,9 +1,11 @@
 <div class="container">
-  <%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
   <% unless @lockbox_partner.nil? || @lockbox_partner.active? %>
     <p class="text-center">Lockbox partner not yet active. There must be an active user and a completed cash addition.</p>
   <% else %>
     <div id="support-request-form" class="container">
+      <% if @lockbox_partner %>
+        <%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
+      <% end %>
       <% form_post_path = @lockbox_partner ? lockbox_partner_support_requests_path(@lockbox_partner) : support_requests_path %>
       <%= form_with model: @support_request, url: form_post_path, class: 'form' do |f| %>
         <h2>File a support request</h2>

--- a/app/views/lockbox_partners/support_requests/new.html.erb
+++ b/app/views/lockbox_partners/support_requests/new.html.erb
@@ -1,47 +1,50 @@
-<div id="support-request-form" class="container">
-  <% form_post_path = @lockbox_partner ? lockbox_partner_support_requests_path(@lockbox_partner) : support_requests_path %>
+<div class="container">
+  <%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
   <% unless @lockbox_partner.nil? || @lockbox_partner.active? %>
     <p class="text-center">Lockbox partner not yet active. There must be an active user and a completed cash addition.</p>
   <% else %>
-    <%= form_with model: @support_request, url: form_post_path, class: 'form' do |f| %>
-      <h2>File a support request</h2>
-      <div class="form-group">
-        <%= label_tag 'lockbox_action[eff_date]', 'Pick-up Date' %>
-        <%= date_field_tag 'lockbox_action[eff_date]', nil, class: 'form-control' %>
-      </div>
-      <% if @lockbox_partner.nil? %>
+    <div id="support-request-form" class="container">
+      <% form_post_path = @lockbox_partner ? lockbox_partner_support_requests_path(@lockbox_partner) : support_requests_path %>
+      <%= form_with model: @support_request, url: form_post_path, class: 'form' do |f| %>
+        <h2>File a support request</h2>
         <div class="form-group">
-          <%= f.label :lockbox_partner %>
-          <%= f.select :lockbox_partner_id, options_for_select(active_lockbox_partner_select_options), {}, class: 'form-control' %>
+          <%= label_tag 'lockbox_action[eff_date]', 'Pick-up Date' %>
+          <%= date_field_tag 'lockbox_action[eff_date]', nil, class: 'form-control' %>
         </div>
-      <% end %>
-      <div class="form-group">
-        <%= f.label :name_or_alias, 'Client Alias' %>
-        <small class="form-text text-muted">Please do not use legal name</small>
-        <%= f.text_field :name_or_alias, class: 'form-control' %>
-      </div>
-      <div class="form-group">
-        <%= f.label :client_ref_id, 'Client Reference ID' %>
-        <%= f.text_field :client_ref_id, class: 'form-control' %>
-      </div>
-      <div class="form-group">
-        <%= f.label :amount_breakdown %>
-        <div class="support_case_transactions">
-          <div class="entries">
-            <% 3.times do %>
-              <%= render partial: 'lockbox_partners/support_requests/lockbox_transaction_form' %>
-            <% end %>
+        <% if @lockbox_partner.nil? %>
+          <div class="form-group">
+            <%= f.label :lockbox_partner %>
+            <%= f.select :lockbox_partner_id, options_for_select(active_lockbox_partner_select_options), {}, class: 'form-control' %>
           </div>
-          <%= link_to 'Add more values +', '#', id: 'add_transaction' %>
+        <% end %>
+        <div class="form-group">
+          <%= f.label :name_or_alias, 'Client Alias' %>
+          <small class="form-text text-muted">Please do not use legal name</small>
+          <%= f.text_field :name_or_alias, class: 'form-control' %>
         </div>
-      </div>
-      <legend id="total">Total: $0.00</legend>
-      <div class="form-group">
-        <%= f.label :urgency_flag %>
-        <%= f.text_field :urgency_flag, class: 'form-control' %>
-      </div>
-      <%= f.submit "Submit", class: 'btn btn-primary' %>
-    <% end %>
-    <script id="transaction_template" type="text/template"><%= render partial: 'lockbox_partners/support_requests/lockbox_transaction_form' %></script>
+        <div class="form-group">
+          <%= f.label :client_ref_id, 'Client Reference ID' %>
+          <%= f.text_field :client_ref_id, class: 'form-control' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :amount_breakdown %>
+          <div class="support_case_transactions">
+            <div class="entries">
+              <% 3.times do %>
+                <%= render partial: 'lockbox_partners/support_requests/lockbox_transaction_form' %>
+              <% end %>
+            </div>
+            <%= link_to 'Add more values +', '#', id: 'add_transaction' %>
+          </div>
+        </div>
+        <legend id="total">Total: $0.00</legend>
+        <div class="form-group">
+          <%= f.label :urgency_flag %>
+          <%= f.text_field :urgency_flag, class: 'form-control' %>
+        </div>
+        <%= f.submit "Submit", class: 'btn btn-primary' %>
+      <% end %>
+      <script id="transaction_template" type="text/template"><%= render partial: 'lockbox_partners/support_requests/lockbox_transaction_form' %></script>
+    </div>
   <% end %>
 </div>

--- a/app/views/lockbox_partners/support_requests/show.html.erb
+++ b/app/views/lockbox_partners/support_requests/show.html.erb
@@ -1,27 +1,19 @@
 <div class="container">
-  <div class="lockbox-partner-header">
-    <strong><%= @support_request&.lockbox_partner&.city %></strong>
-    <%= link_to lockbox_partner_path(@support_request.lockbox_partner), class: 'float-right' do %>
-      <i class="fa fa-long-arrow-left" aria-hidden="true"></i> View All Activity
+  <%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
+  <div class="support-request-container">
+    <% if current_user.admin? %>
+      <%= render partial: 'details_admin', locals: { support_request: @support_request } %>
+      <%= link_to 'Edit Support Request', 'TODO', class: 'btn btn-primary' %>
+      <%= link_to 'Add Note', '#', class: 'btn btn-secondary', id: 'new-note' %>
+    <% else %>
+      <%= render partial: 'details_partner', locals: { support_request: @support_request } %>
+      <%= link_to 'Add Note', '#', class: 'btn btn-primary', id: 'new-note' %>
     <% end %>
-    <h2><%= @support_request&.lockbox_partner&.name %> <span class="float-right"><%= @support_request&.lockbox_partner&.balance %></span></h2>
-  </div>
-  <div class="header-separator"></div>
-    <div class="support-request-container">
-      <% if current_user.admin? %>
-        <%= render partial: 'details_admin', locals: { support_request: @support_request } %>
-        <%= link_to 'Edit Support Request', 'TODO', class: 'btn btn-primary' %>
-        <%= link_to 'Add Note', '#', class: 'btn btn-secondary', id: 'new-note' %>
-      <% else %>
-        <%= render partial: 'details_partner', locals: { support_request: @support_request } %>
-        <%= link_to 'Add Note', '#', class: 'btn btn-primary', id: 'new-note' %>
-      <% end %>
 
-      <%= render partial: 'lockbox_partners/notes/notes', locals: { notable: @support_request } %>
+    <%= render partial: 'lockbox_partners/notes/notes', locals: { notable: @support_request } %>
 
-      <div class="support-request-nav">
-        TODO MAKE THIS NAV - https://github.com/MidwestAccessCoalition/lockbox_rails/issues/121
-      </div>
+    <div class="support-request-nav">
+      TODO MAKE THIS NAV - https://github.com/MidwestAccessCoalition/lockbox_rails/issues/121
     </div>
   </div>
 </div>

--- a/app/views/lockbox_partners/users/new.html.erb
+++ b/app/views/lockbox_partners/users/new.html.erb
@@ -1,6 +1,7 @@
 <div class="container">
-  <h3>Invite new user to <%= @lockbox_partner.name %></h3>
-  <%= form_for @user, url: lockbox_partner_users_path(@lockbox_partner), html: { class: 'form' } do |f| %>
+  <%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
+  <%= form_for @user, url: lockbox_partner_users_path(@lockbox_partner), html: { class: "form new-user-form" } do |f| %>
+    <h3>Invite new user to <%= @lockbox_partner.name %></h3>
     <div class=<%= @user.errors[:email].present? ? "form-group usa-input-error" : "form-group" %>>
       <%= f.label :email %>
       <% if @user.errors[:email].present? %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,8 +20,9 @@ LOCKBOX_PARTNERS = [
 
 LOCKBOX_PARTNERS.map do |partner_name, partner_user_email|
   lockbox_partner = LockboxPartner.where(name: partner_name).first_or_create!(
+    street_address: Faker::Address.street_address,
     city: Faker::Address.city,
-    state: Faker::Address.state,
+    state: Faker::Address.state_abbr,
     zip_code: Faker::Address.zip_code,
     phone_number: Faker::PhoneNumber.phone_number
   )
@@ -50,10 +51,11 @@ LOCKBOX_PARTNERS.map do |partner_name, partner_user_email|
     lockbox_partner: lockbox_partner,
     user: User.first
   ).tap do |sup_req|
-    action = sup_req.lockbox_actions.create!(
+    action = LockboxAction.create(
       eff_date: Date.current + (1..10).to_a.sample.days,
       action_type: LockboxAction::SUPPORT_CLIENT,
-      lockbox_partner: lockbox_partner
+      lockbox_partner: lockbox_partner,
+      support_request_id: sup_req.id
     )
 
     categories = LockboxTransaction::EXPENSE_CATEGORIES.sample((1..3).to_a.sample)


### PR DESCRIPTION
## Changelog
- Include lockbox partner header at the top of all lockbox partner views
- Change the seedfile to include street address, fixed regression in seed file
- Address and phone number now show in lockbox partner header

## Link to issue:  
#190 

## Relevant Screenshots: 
<img width="1221" alt="Screen Shot 2019-09-15 at 5 08 00 PM" src="https://user-images.githubusercontent.com/4739591/64928287-98084800-d7db-11e9-92b4-0ea0394d7a66.png">

## Are you ready for review?:
- [x] Linked PR to the issue
- [x] Added revelant screenshots
