### PR TITLE
rearrange cash addition workflow

### DIFF
--- a/app/controllers/lockbox_partners/add_cash_controller.rb
+++ b/app/controllers/lockbox_partners/add_cash_controller.rb
@@ -2,7 +2,7 @@ require 'add_cash_to_lockbox'
 
 class LockboxPartners::AddCashController < ApplicationController
   before_action :set_lockbox_partner, only: :create
-  before_action :require_admin_or_ownership
+  before_action :require_admin
 
   def new
   end

--- a/app/controllers/lockbox_partners/add_cash_controller.rb
+++ b/app/controllers/lockbox_partners/add_cash_controller.rb
@@ -1,7 +1,8 @@
 require 'add_cash_to_lockbox'
 
 class LockboxPartners::AddCashController < ApplicationController
-  before_action :set_lockbox_partner, :require_admin_or_ownership
+  before_action :set_lockbox_partner, only: :create
+  before_action :require_admin_or_ownership
 
   def new
   end
@@ -13,9 +14,11 @@ class LockboxPartners::AddCashController < ApplicationController
       eff_date: Date.current
     )
     if action.succeeded?
-      # TODO figure out what should happen
+      formatted_amount = "%0.2f" % action.value.amount.to_f
+      flash[:notice] = "$#{formatted_amount} added to lockbox"
       redirect_to lockbox_partner_path(@lockbox_partner)
     else
+      flash[:alert] = "Sorry, there was a problem."
       render 'new'
     end
   end
@@ -24,7 +27,7 @@ class LockboxPartners::AddCashController < ApplicationController
 
   # TODO refactor this into a module
   def set_lockbox_partner
-    @lockbox_partner = LockboxPartner.find(params[:lockbox_partner_id])
+    @lockbox_partner = LockboxPartner.find(add_cash_params[:lockbox_partner_id])
   end
 
   def add_cash_params

--- a/app/views/layouts/_secondary_nav.html.erb
+++ b/app/views/layouts/_secondary_nav.html.erb
@@ -11,7 +11,7 @@
       } %>
       <%= render partial: 'layouts/secondary_tab', locals: {
         tab_name: 'Add cash to lockbox',
-        tab_path: new_lockbox_partner_add_cash_path(@lockbox_partner)
+        tab_path: new_lockbox_partners_add_cash_path(lockbox_partner_id: @lockbox_partner)
       } %>
       <%= render partial: 'layouts/secondary_tab', locals: {
         tab_name: 'Manage lockbox partner',

--- a/app/views/lockbox_partner_mailer/low_balance_alert.html.erb
+++ b/app/views/lockbox_partner_mailer/low_balance_alert.html.erb
@@ -7,7 +7,7 @@
     </div>
 
     <div>
-      Please <%= link_to "add cash to this lockbox", new_lockbox_partner_add_cash_url(@lockbox_partner) %>
+      Please <%= link_to "add cash to this lockbox", new_lockbox_partners_add_cash_url(lockbox_partner_id: @lockbox_partner) %>
     </div>
   </body>
 </html>

--- a/app/views/lockbox_partner_mailer/low_balance_alert.text.erb
+++ b/app/views/lockbox_partner_mailer/low_balance_alert.text.erb
@@ -1,3 +1,3 @@
 Heads up! The lockbox balance at <%= @lockbox_partner.name %> is at $<%= @lockbox_partner.balance.to_s %> when taking into account all pending support requests. 
 
-Please add cash to the lockbox here: <%= new_lockbox_partner_add_cash_url(@lockbox_partner) %>
+Please add cash to the lockbox here: <%= new_lockbox_partners_add_cash_url(lockbox_partner_id: @lockbox_partner.id) %>

--- a/app/views/lockbox_partners/add_cash/new.html.erb
+++ b/app/views/lockbox_partners/add_cash/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <%= form_for :add_cash, class: "form", url: lockbox_partner_add_cash_path do |f| %>
+  <%= form_for :add_cash, class: "form", url: lockbox_partners_add_cash_path do |f| %>
     <h2>Add Cash to Lockbox</h2>
     <p>Complete this form when you have put the check in the mail</p>
     <div class="form-group">
@@ -8,7 +8,7 @@
     </div>
     <div class="form-group">
       <%= f.label "Partner Clinic" %>
-      <%= f.select :lockbox_partner_id, options_for_select(lockbox_partner_select_options, @lockbox_partner.id), {}, class: 'form-control' %>
+      <%= f.select :lockbox_partner_id, options_for_select(lockbox_partner_select_options, params[:lockbox_partner_id]), {}, class: 'form-control' %>
     </div>
     <%= f.submit "Submit", class: "btn btn-primary" %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,11 @@ Rails.application.routes.draw do
         post 'update_status', to: 'support_requests#update_status', as: 'update_status'
         resources :notes, only: [:create]
       end
-      resource :add_cash, only: [:new, :create], controller: 'add_cash'
       resource :reconciliation, only: [:new, :create], controller: 'reconciliation'
     end
+  end
+
+  namespace :lockbox_partners do
+    resource :add_cash, only: [:new, :create], controller: 'add_cash'
   end
 end

--- a/spec/controllers/lockbox_partners/add_cash_controller_spec.rb
+++ b/spec/controllers/lockbox_partners/add_cash_controller_spec.rb
@@ -1,15 +1,14 @@
 require 'rails_helper'
 
 describe LockboxPartners::AddCashController do
-  let(:authorized_lockbox_partner) { create(:lockbox_partner, :active) }
-  let(:unauthorized_lockbox_partner) { create(:lockbox_partner, :active) }
+  let(:lockbox_partner) { create(:lockbox_partner, :active) }
 
   let(:user) { create(:user, role: user_role, lockbox_partner: user_lockbox_partner) }
 
   describe "#new" do
     before do
       sign_in(user)
-      get :new, params: { lockbox_partner_id: authorized_lockbox_partner.id }
+      get :new, params: { lockbox_partner_id: lockbox_partner.id }
     end
 
     context "when the user is an admin" do
@@ -21,18 +20,9 @@ describe LockboxPartners::AddCashController do
       end
     end
 
-    context "when the user belongs to the correct partner" do
+    context "when the user is not an admin" do
       let(:user_role) { User::PARTNER }
-      let(:user_lockbox_partner) { authorized_lockbox_partner }
-
-      it "returns 200" do
-        expect(response.status).to eq(200)
-      end
-    end
-
-    context "when the user does not belong to the correct partner" do
-      let(:user_role) { User::PARTNER }
-      let(:user_lockbox_partner) { unauthorized_lockbox_partner }
+      let(:user_lockbox_partner) { lockbox_partner }
 
       it "returns 302" do
         expect(response.status).to eq(302)


### PR DESCRIPTION
As a MAC user, when I successfully add cash to the lockbox, the form currently redirects to the lockbox partner view and doesn't show any message to the user. I want to be shown a confirmation screen on that redirect.

## Changelog
* Since the user can change the partner in the form, move the `add_cash` route out of the partner resource so the form path doesn't require and ID
* Redirect to the selected partner upon successful submission
* Add success/failure messages

## Link to issue:  
Fixes issue #113 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
- super important for UI tasks!


## Are you ready for review?:

- [x] ~Added relevant tests~
- [x] Linked PR to the issue
- [x] ~Added notes for QA/special notes~
- [x] ~Added revelant screenshots~
