### PR TITLE
[113] Fix behavior on successful add cash submit

### DIFF
--- a/app/controllers/lockbox_partners/add_cash_controller.rb
+++ b/app/controllers/lockbox_partners/add_cash_controller.rb
@@ -8,14 +8,16 @@ class LockboxPartners::AddCashController < ApplicationController
 
   def create
     action = AddCashToLockbox.call(
-      lockbox_partner: LockboxPartner.find(add_cash_params[:lockbox_partner_id]),
+      lockbox_partner: @lockbox_partner,
       amount: add_cash_params[:amount],
       eff_date: Date.current
     )
     if action.succeeded?
-      # TODO figure out what should happen
+      formatted_amount = "%0.2f" % action.value.amount.to_f
+      flash[:notice] = "Success! $#{formatted_amount} added to #{@lockbox_partner.name} lockbox."
       redirect_to lockbox_partner_path(@lockbox_partner)
     else
+      flash[:alert] = "Sorry, there was a problem."
       render 'new'
     end
   end
@@ -28,6 +30,6 @@ class LockboxPartners::AddCashController < ApplicationController
   end
 
   def add_cash_params
-    params.require(:add_cash).permit(:lockbox_partner_id, :amount)
+    params.require(:add_cash).permit(:amount)
   end
 end

--- a/app/controllers/lockbox_partners/add_cash_controller.rb
+++ b/app/controllers/lockbox_partners/add_cash_controller.rb
@@ -1,7 +1,7 @@
 require 'add_cash_to_lockbox'
 
 class LockboxPartners::AddCashController < ApplicationController
-  before_action :set_lockbox_partner, :require_admin_or_ownership
+  before_action :set_lockbox_partner, :require_admin
 
   def new
   end

--- a/app/views/lockbox_partners/add_cash/new.html.erb
+++ b/app/views/lockbox_partners/add_cash/new.html.erb
@@ -7,10 +7,6 @@
       <%= f.label "Cash Added" %>
       <%= f.text_field :amount, type: "number", step: "0.01", class: "form-control" %>
     </div>
-    <div class="form-group">
-      <%= f.label "Partner Clinic" %>
-      <%= f.select :lockbox_partner_id, options_for_select(lockbox_partner_select_options, @lockbox_partner.id), {}, class: 'form-control' %>
-    </div>
     <%= f.submit "Submit", class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/spec/controllers/lockbox_partners/add_cash_controller_spec.rb
+++ b/spec/controllers/lockbox_partners/add_cash_controller_spec.rb
@@ -1,15 +1,14 @@
 require 'rails_helper'
 
 describe LockboxPartners::AddCashController do
-  let(:authorized_lockbox_partner) { create(:lockbox_partner, :active) }
-  let(:unauthorized_lockbox_partner) { create(:lockbox_partner, :active) }
+  let(:lockbox_partner) { create(:lockbox_partner, :active) }
 
   let(:user) { create(:user, role: user_role, lockbox_partner: user_lockbox_partner) }
 
   describe "#new" do
     before do
       sign_in(user)
-      get :new, params: { lockbox_partner_id: authorized_lockbox_partner.id }
+      get :new, params: { lockbox_partner_id: lockbox_partner.id }
     end
 
     context "when the user is an admin" do
@@ -21,18 +20,9 @@ describe LockboxPartners::AddCashController do
       end
     end
 
-    context "when the user belongs to the correct partner" do
+    context "when the user is not an admin" do
       let(:user_role) { User::PARTNER }
-      let(:user_lockbox_partner) { authorized_lockbox_partner }
-
-      it "returns 200" do
-        expect(response.status).to eq(200)
-      end
-    end
-
-    context "when the user does not belong to the correct partner" do
-      let(:user_role) { User::PARTNER }
-      let(:user_lockbox_partner) { unauthorized_lockbox_partner }
+      let(:user_lockbox_partner) { lockbox_partner }
 
       it "returns 302" do
         expect(response.status).to eq(302)


### PR DESCRIPTION
## Changelog
- Flash messages for adding cash
- Don't allow partners to add cash
- Remove ability to change partner in the add-cash form.
    - This was to prevent confusion in the URLs.  It doesn't make sense to
        `POST /lockbox_partners/3/add_cash` when you're actually going to add cash to partner with ID `2`.

## Link to issue:  
Fixes issue #113


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
- super important for UI tasks!


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
