### PR TITLE
editing notes

### DIFF
--- a/app/assets/stylesheets/notes.scss
+++ b/app/assets/stylesheets/notes.scss
@@ -19,4 +19,24 @@
   tr.green {
     background: #e7f4e5;
   }
+  a.disabled {
+    color: gray;
+    pointer-events: none;
+  }
+  tr {
+    textarea {
+      width: 100%;
+    }
+    .buttons {
+      height: 39px;
+      * {
+        float: right;
+        margin-left: 20px;
+      }
+      a {
+        vertical-align: middle;
+        line-height: 39px;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/notes.scss
+++ b/app/assets/stylesheets/notes.scss
@@ -16,4 +16,7 @@
 
 .notes-log .table {
   border-top: 0px;
+  tr.green {
+    background: #e7f4e5;
+  }
 }

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -22,6 +22,7 @@
       display: inline-block;
       text-decoration: none;
       padding: 17px;
+      width: 250px;
       .btn {
         width: 100%;
       }
@@ -54,6 +55,13 @@
         vertical-align: middle;
         line-height: 39px;
       }
+    }
+  }
+  #note-success {
+    display: none;
+    background: silver;
+    .container {
+      padding: 20px;
     }
   }
 

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -15,11 +15,48 @@
   color: black;
   margin: 10px auto;
   margin-top: 0;
-  .btn {
-    margin: 20px auto;
-    margin-right: 20px;
-    width: 25%;
+  .tabs {
+    padding: 0;
+    margin: 0;
+    .tab {
+      display: inline-block;
+      text-decoration: none;
+      padding: 17px;
+      .btn {
+        width: 100%;
+      }
+    }
+    .tab.selected {
+      background: silver;
+    }
   }
+  #new-note-form {
+    background: silver;
+    .container {
+      padding: 20px;
+    }
+    .textarea {
+      width: 500px;
+      textarea {
+        height: 180px;
+      }
+    }
+    .buttons {
+      width: 500px;
+      height: 39px;
+      padding: 10px;
+      * {
+        display: inline-block;
+        float: right;
+        margin-left: 20px;
+      }
+      a {
+        vertical-align: middle;
+        line-height: 39px;
+      }
+    }
+  }
+
   .dropdown-toggle {
     margin: 0;
     width: 160px;

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -1,3 +1,5 @@
+$note-form-color: #d6d7d9;
+
 #support-requests-index {
   max-width: 600px;
   margin: 0 auto;
@@ -28,11 +30,11 @@
       }
     }
     .tab.selected {
-      background: silver;
+      background: $note-form-color;
     }
   }
   #new-note-form {
-    background: silver;
+    background: $note-form-color;
     .container {
       padding: 20px;
     }
@@ -59,9 +61,15 @@
   }
   #note-success {
     display: none;
-    background: silver;
+    background: $note-form-color;
     .container {
       padding: 20px;
+    }
+    i {
+      color: #17a729;
+    }
+    a {
+      text-decoration: underline;
     }
   }
 

--- a/app/controllers/lockbox_partners/notes_controller.rb
+++ b/app/controllers/lockbox_partners/notes_controller.rb
@@ -1,5 +1,6 @@
 class LockboxPartners::NotesController < ApplicationController
   before_action :find_commentable, only: %w[create]
+  before_action :find_note, except: [:create]
 
   def create
     @note = @commentable.notes.build(note_params.merge(user_id: current_user.id))
@@ -26,10 +27,42 @@ class LockboxPartners::NotesController < ApplicationController
     end
   end
 
+  def show
+    render partial: 'lockbox_partners/notes/note', locals: { note: @note }
+  end
+
+  def edit
+    render 'lockbox_partners/notes/edit', layout: false
+  end
+
+  def update
+    if @note.update(note_params)
+      render json: {
+        note: render_to_string(
+          partial: 'lockbox_partners/notes/note',
+          locals: {
+            note: @note
+          }
+        ),
+        text: @note.text
+      }
+    else
+      render json: {
+        error: render_to_string(
+          partial: 'shared/error',
+          locals: {
+            key: 'alert',
+            value: @note.errors.full_messages.join(', ')
+          }
+        )
+      }
+    end
+  end
+
   private
 
   def note_params
-    params.require(:note).permit(:text)
+    params.require(:note).permit(:id, :text)
   end
 
   def find_commentable
@@ -42,5 +75,9 @@ class LockboxPartners::NotesController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       return head :bad_request
     end
+  end
+
+  def find_note
+    @note = Note.find(params[:id])
   end
 end

--- a/app/controllers/lockbox_partners/notes_controller.rb
+++ b/app/controllers/lockbox_partners/notes_controller.rb
@@ -10,7 +10,8 @@ class LockboxPartners::NotesController < ApplicationController
           locals: {
             note: @note
           }
-        )
+        ),
+        text: @note.text
       }
     else
       render json: {

--- a/app/javascript/src/notes.js
+++ b/app/javascript/src/notes.js
@@ -1,5 +1,6 @@
 const addNewNote = note => {
   $('tbody').prepend(note);
+  highlightTopNote();
 };
 
 const openNoteForm = () => {
@@ -8,6 +9,27 @@ const openNoteForm = () => {
     .parent()
     .addClass('selected');
   $('#new-note-form textarea').focus();
+};
+
+const displayNoteSuccess = text => {
+  $('#note-success #note-text').text(text);
+  $('#note-success').slideDown(250);
+};
+
+const hideNoteSuccess = () => {
+  $('#note-success').slideUp(250);
+  clearHighlights();
+};
+
+const clearHighlights = () => {
+  $('.notes-log tbody tr').removeClass('green');
+};
+
+const highlightTopNote = () => {
+  clearHighlights();
+  $('.notes-log tbody tr')
+    .first()
+    .addClass('green');
 };
 
 const clearNoteForm = () => {
@@ -23,6 +45,7 @@ const handleNoteResponse = response => {
   if (data.note) {
     addNewNote(data.note);
     clearNoteForm();
+    displayNoteSuccess(data.text);
   }
 };
 
@@ -32,10 +55,12 @@ const setupNotes = () => {
     $('#new-note').on('click', event => {
       event.preventDefault();
       openNoteForm();
+      hideNoteSuccess();
     });
     $('#cancel-note').on('click', event => {
       event.preventDefault();
       clearNoteForm();
+      hideNoteSuccess();
     });
     document.removeEventListener('ajax:success', handleNoteResponse);
     document.addEventListener('ajax:success', handleNoteResponse);

--- a/app/javascript/src/notes.js
+++ b/app/javascript/src/notes.js
@@ -35,6 +35,9 @@ const highlightTopNote = () => {
 const clearNoteForm = () => {
   $('#new-note-form').slideUp(250);
   $('#new-note-form textarea').val('');
+};
+
+const removeSelection = () => {
   $('#new-note')
     .parent()
     .removeClass('selected');
@@ -46,6 +49,8 @@ const handleNoteResponse = response => {
     addNewNote(data.note);
     clearNoteForm();
     displayNoteSuccess(data.text);
+  } else {
+    console.log(data);
   }
 };
 
@@ -60,6 +65,13 @@ const setupNotes = () => {
     $('#cancel-note').on('click', event => {
       event.preventDefault();
       clearNoteForm();
+      removeSelection();
+      hideNoteSuccess();
+    });
+    $('#success-new-note').on('click', event => {
+      event.preventDefault();
+      clearNoteForm();
+      openNoteForm();
       hideNoteSuccess();
     });
     document.removeEventListener('ajax:success', handleNoteResponse);

--- a/app/javascript/src/notes.js
+++ b/app/javascript/src/notes.js
@@ -4,6 +4,9 @@ const handleNoteResponse = response => {
     $('tbody').prepend(data.note);
     $('#new-note-form').slideUp(250);
     $('#new-note-form textarea').val('');
+    $('#new-note')
+      .parent()
+      .removeClass('selected');
   }
 };
 
@@ -13,7 +16,8 @@ const setupNotes = () => {
     const newNoteButton = $('#new-note');
     newNoteButton.on('click', event => {
       event.preventDefault();
-      const newNoteForm = $('#new-note-form').slideDown(250);
+      $('#new-note-form').slideDown(250);
+      newNoteButton.parent().addClass('selected');
     });
     document.removeEventListener('ajax:success', handleNoteResponse);
     document.addEventListener('ajax:success', handleNoteResponse);

--- a/app/javascript/src/notes.js
+++ b/app/javascript/src/notes.js
@@ -1,23 +1,41 @@
+const addNewNote = note => {
+  $('tbody').prepend(note);
+};
+
+const openNoteForm = () => {
+  $('#new-note-form').slideDown(250);
+  $('#new-note')
+    .parent()
+    .addClass('selected');
+  $('#new-note-form textarea').focus();
+};
+
+const clearNoteForm = () => {
+  $('#new-note-form').slideUp(250);
+  $('#new-note-form textarea').val('');
+  $('#new-note')
+    .parent()
+    .removeClass('selected');
+};
+
 const handleNoteResponse = response => {
   const data = response.detail[0];
   if (data.note) {
-    $('tbody').prepend(data.note);
-    $('#new-note-form').slideUp(250);
-    $('#new-note-form textarea').val('');
-    $('#new-note')
-      .parent()
-      .removeClass('selected');
+    addNewNote(data.note);
+    clearNoteForm();
   }
 };
 
 const setupNotes = () => {
   const notesLog = $('.notes-log');
   if (notesLog) {
-    const newNoteButton = $('#new-note');
-    newNoteButton.on('click', event => {
+    $('#new-note').on('click', event => {
       event.preventDefault();
-      $('#new-note-form').slideDown(250);
-      newNoteButton.parent().addClass('selected');
+      openNoteForm();
+    });
+    $('#cancel-note').on('click', event => {
+      event.preventDefault();
+      clearNoteForm();
     });
     document.removeEventListener('ajax:success', handleNoteResponse);
     document.addEventListener('ajax:success', handleNoteResponse);

--- a/app/javascript/src/notes.js
+++ b/app/javascript/src/notes.js
@@ -12,6 +12,13 @@ const openNoteForm = () => {
 };
 
 const displayNoteSuccess = text => {
+  $('#note-success #note-event').text('New note created');
+  $('#note-success #note-text').text(text);
+  $('#note-success').slideDown(250);
+};
+
+const displayNoteUpdate = text => {
+  $('#note-success #note-event').text('Note updated');
   $('#note-success #note-text').text(text);
   $('#note-success').slideDown(250);
 };
@@ -27,9 +34,11 @@ const clearHighlights = () => {
 
 const highlightTopNote = () => {
   clearHighlights();
-  $('.notes-log tbody tr')
-    .first()
-    .addClass('green');
+  highlightNote($('.notes-log tbody tr').first());
+};
+
+const highlightNote = note => {
+  note.addClass('green');
 };
 
 const clearNoteForm = () => {
@@ -49,6 +58,40 @@ const handleNoteResponse = response => {
     addNewNote(data.note);
     clearNoteForm();
     displayNoteSuccess(data.text);
+  } else {
+    console.log(data);
+  }
+};
+
+const editGreenNote = () => {
+  const greenNote = $('tr.green');
+  getNoteForm(greenNote);
+};
+
+const getNoteForm = note => {
+  const id = note.data('id');
+  const noteEditUrl = window.location + '/notes/' + note.data('id') + '/edit';
+  $.ajax(noteEditUrl).done(response => {
+    note.replaceWith(response);
+    const newNote = $(`tr[data-id=${id}]`);
+    newNote.on('ajax:success', handleUpdateNote);
+    newNote.find('textarea').focus();
+  });
+};
+
+const cancelNoteForm = note => {
+  const noteShowUrl = window.location + '/notes/' + note.data('id');
+  $.ajax(noteShowUrl).done(response => note.replaceWith(response));
+};
+
+const handleUpdateNote = response => {
+  const data = response.detail[0];
+  if (data.note) {
+    const note = $(response.target).closest('tr');
+    const id = note.data('id');
+    note.replaceWith(data.note);
+    highlightNote($(`tr[data-id=${id}]`));
+    displayNoteUpdate(data.text);
   } else {
     console.log(data);
   }
@@ -74,8 +117,24 @@ const setupNotes = () => {
       openNoteForm();
       hideNoteSuccess();
     });
-    document.removeEventListener('ajax:success', handleNoteResponse);
-    document.addEventListener('ajax:success', handleNoteResponse);
+    $('#success-edit-note').on('click', event => {
+      event.preventDefault();
+      editGreenNote();
+      hideNoteSuccess();
+      removeSelection();
+    });
+    notesLog.on('click', '.edit-note-button', event => {
+      event.preventDefault();
+      getNoteForm($(event.target).closest('tr'));
+      hideNoteSuccess();
+      removeSelection();
+    });
+    notesLog.on('click', '.cancel-note', event => {
+      event.preventDefault();
+      cancelNoteForm($(event.target).closest('tr'));
+    });
+    $('#new-note-form').off('ajax:success', handleNoteResponse);
+    $('#new-note-form').on('ajax:success', handleNoteResponse);
   }
 };
 

--- a/app/views/lockbox_partners/notes/_note.html.erb
+++ b/app/views/lockbox_partners/notes/_note.html.erb
@@ -1,5 +1,6 @@
-<tr>
+<tr data-id="<%= note.id %>">
   <td><%= note.created_at.strftime('%Y/%m/%d %I:%M %p') %></td>
   <td><%= note.author %></td>
   <td><%= note.text %></td>
+  <td class="font-weight-bold"><a href="#" class="edit-note-button">Edit <%= fa_icon "arrow-right" %></a></td>
 </tr>

--- a/app/views/lockbox_partners/notes/_notes.html.erb
+++ b/app/views/lockbox_partners/notes/_notes.html.erb
@@ -13,10 +13,10 @@
   <div class="container">
     <p class="font-weight-bold">
       <%= fa_icon "check-circle" %>
-      New note created:
+      <span id="note-event">New note created</span>:
     </p>
     <p id="note-text"></p>
-    <p><a href="#" id="edit-note">Edit note</a> or <a href="#" id="success-new-note">add a new one</a>.</p>
+    <p><a href="#" id="success-edit-note">Edit note</a> or <a href="#" id="success-new-note">add a new one</a>.</p>
   </div>
 </div>
 <div class="notes-log">
@@ -26,10 +26,11 @@
         <th>Date</th>
         <th>Commentor</th>
         <th>Note</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
-      <%= render notable.notes %>
+      <%= render notable.notes.order(created_at: :desc) %>
     </tbody>
   </table>
 </div>

--- a/app/views/lockbox_partners/notes/_notes.html.erb
+++ b/app/views/lockbox_partners/notes/_notes.html.erb
@@ -11,8 +11,12 @@
 <% end %>
 <div id="note-success">
   <div class="container">
-    <p class="font-weight-bold">New note created:</p>
+    <p class="font-weight-bold">
+      <%= fa_icon "check-circle" %>
+      New note created:
+    </p>
     <p id="note-text"></p>
+    <p><a href="#" id="edit-note">Edit note</a> or <a href="#" id="success-new-note">add a new one</a>.</p>
   </div>
 </div>
 <div class="notes-log">

--- a/app/views/lockbox_partners/notes/_notes.html.erb
+++ b/app/views/lockbox_partners/notes/_notes.html.erb
@@ -9,6 +9,12 @@
     </div>
   </div>
 <% end %>
+<div id="note-success">
+  <div class="container">
+    <p class="font-weight-bold">New note created:</p>
+    <p id="note-text"></p>
+  </div>
+</div>
 <div class="notes-log">
   <table class="table">
     <thead>

--- a/app/views/lockbox_partners/notes/_notes.html.erb
+++ b/app/views/lockbox_partners/notes/_notes.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="buttons">
       <%= f.submit 'Save Note', class: 'btn btn-primary' %>
-      <a href="#">Cancel</a>
+      <a href="#" id="cancel-note">Cancel</a>
     </div>
   </div>
 <% end %>

--- a/app/views/lockbox_partners/notes/_notes.html.erb
+++ b/app/views/lockbox_partners/notes/_notes.html.erb
@@ -1,7 +1,12 @@
 <%= form_with model: Note.new, url: lockbox_partner_support_request_notes_path(notable.lockbox_partner, notable), id: 'new-note-form' do |f| %>
-  <%= f.submit 'Save Note', class: 'btn btn-primary' %>
-  <div class="textarea">
-    <%= f.text_area :text %>
+  <div class="container">
+    <div class="textarea">
+      <%= f.text_area :text %>
+    </div>
+    <div class="buttons">
+      <%= f.submit 'Save Note', class: 'btn btn-primary' %>
+      <a href="#">Cancel</a>
+    </div>
   </div>
 <% end %>
 <div class="notes-log">

--- a/app/views/lockbox_partners/notes/edit.html.erb
+++ b/app/views/lockbox_partners/notes/edit.html.erb
@@ -1,0 +1,16 @@
+<tr data-id="<%= @note.id %>">
+  <td><%= @note.created_at.strftime('%Y/%m/%d %I:%M %p') %></td>
+  <td><%= @note.author %></td>
+  <td>
+    <%= form_for @note, url: lockbox_partner_support_request_note_path(@note), id: 'new-note-form', remote: true do |f| %>
+      <div class="textarea">
+        <%= f.text_area :text %>
+      </div>
+      <div class="buttons">
+        <%= f.submit 'Save Note', class: 'btn btn-primary' %>
+        <a href="#" class="cancel-note">Cancel</a>
+      </div>
+    <% end %>
+  </td>
+  <td class="font-weight-bold"><a href="#" class="edit-note disabled">Edit <%= fa_icon "arrow-right" %></a></td>
+</tr>

--- a/app/views/lockbox_partners/support_requests/show.html.erb
+++ b/app/views/lockbox_partners/support_requests/show.html.erb
@@ -3,11 +3,15 @@
   <div class="support-request-container">
     <% if current_user.admin? %>
       <%= render partial: 'details_admin', locals: { support_request: @support_request } %>
-      <%= link_to 'Edit Support Request', edit_lockbox_partner_support_request_path(@support_request.lockbox_partner, @support_request), class: 'btn btn-primary', disabled: !@support_request.editable_status? %>
-      <%= link_to 'Add Note', '#', class: 'btn btn-secondary', id: 'new-note' %>
+      <div class="tabs">
+        <div class="tab"><%= link_to 'Edit Support Request', edit_lockbox_partner_support_request_path(@support_request.lockbox_partner, @support_request), class: 'btn btn-primary', disabled: !@support_request.editable_status? %></div>
+        <div class="tab"><%= link_to 'Add Note', '#', class: 'btn btn-secondary', id: 'new-note' %></div>
+      </div>
     <% else %>
       <%= render partial: 'details_partner', locals: { support_request: @support_request } %>
-      <%= link_to 'Add Note', '#', class: 'btn btn-primary', id: 'new-note' %>
+      <ul class="tabs">
+        <li class="tab"><%= link_to 'Add Note', '#', class: 'btn btn-primary', id: 'new-note' %></li>
+      </ul>
     <% end %>
 
     <%= render partial: 'lockbox_partners/notes/notes', locals: { notable: @support_request } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       resources :users, only: [:new, :create]
       resources :support_requests, except: [:index, :destroy] do
         post 'update_status', to: 'support_requests#update_status', as: 'update_status'
-        resources :notes, only: [:create]
+        resources :notes, only: [:create, :show, :edit, :update]
       end
       resource :add_cash, only: [:new, :create], controller: 'add_cash'
       resource :reconciliation, only: [:new, :create], controller: 'reconciliation'

--- a/spec/system/support_request_actions_spec.rb
+++ b/spec/system/support_request_actions_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Support Request Actions", type: :system do
     login_as(user, :scope => :user)
   end
 
-  xit 'successfully view, edit, and add notes to a support request' do
+  it 'successfully view, edit, and add notes to a support request' do
     visit "/lockbox_partners/#{lockbox_partner.id}/support_requests/#{support_request.id}"
     assert_selector "h3", text: "Support Request for Leafy Greens"
     click_link "Add Note"
@@ -32,6 +32,9 @@ RSpec.describe "Support Request Actions", type: :system do
 
     # Sleep for 1 second to avoid a race condition in slower environments (e.g., CircleCI)
     expect{ click_button "Save Note"; sleep(1) }.to change{ support_request.notes.count }.by(1)
+    click_link "Edit note"
+    fill_in "note_text", with: "foobar"
+    expect{ click_button "Save Note"; sleep(1) }.to change { support_request.notes.last.text }.to("foobar")
   end
 
 end


### PR DESCRIPTION
## Changelog
Note form now matches design
Designed messages appear when note is created
The created note is highlighted
Notes can be edited inline
Message appears when you update a note, similar to note creation

## Relevant Screenshots: 
![Screen Shot 2019-09-29 at 7 21 45 PM](https://user-images.githubusercontent.com/4739591/65842077-71273700-e2ee-11e9-9ced-8a200cda0f9a.png)
<img width="1188" alt="Screen Shot 2019-09-29 at 9 33 51 AM" src="https://user-images.githubusercontent.com/4739591/65842086-87cd8e00-e2ee-11e9-89de-1db749c7d738.png">

## Link to issue:
#201 

## Are you ready for review?:

- [ ] Added relevant tests
- [x] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [x] Added revelant screenshots
