### PR TITLE
Change balance calc for pending cash additions

### DIFF
--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -42,7 +42,11 @@ class LockboxPartner < ApplicationRecord
   def relevant_transactions_for_balance(exclude_pending: false)
     excluded_statuses = [ LockboxAction::CANCELED ]
     excluded_statuses << LockboxAction::PENDING if exclude_pending
-    lockbox_action_ids = LockboxAction.where(lockbox_partner: self).excluding_statuses(excluded_statuses).pluck(:id)
+    actions = LockboxAction.where(lockbox_partner: self).excluding_statuses(excluded_statuses)
+    lockbox_action_ids = actions.map do |action|
+      next if action.pending? && action.action_type == LockboxAction::ADD_CASH
+      action.id
+    end.compact
     LockboxTransaction.where(lockbox_action_id: lockbox_action_ids)
   end
 

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -55,7 +55,7 @@ describe CreateSupportRequest do
     end
 
     before do
-      AddCashToLockbox.call(lockbox_partner: low_balance_lockbox_partner, eff_date: 1.day.ago, amount: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE)
+      AddCashToLockbox.call!(lockbox_partner: low_balance_lockbox_partner, eff_date: 1.day.ago, amount: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE).complete!
     end
 
     it 'goes to the finance team when balance is below $300' do
@@ -82,7 +82,7 @@ describe CreateSupportRequest do
     it 'is not sent when the balance remains above $300' do
       ENV['LOW_BALANCE_ALERT_EMAIL'] ||= 'lowbalance@alert.com'
 
-      AddCashToLockbox.call(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE + Money.new(15000))
+      AddCashToLockbox.call!(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE + Money.new(15000)).complete!
 
       params[:lockbox_action][:lockbox_transactions][0][:amount] = 100
       expect { CreateSupportRequest.call(params: params) }


### PR DESCRIPTION
## Changelog
- Modified the balance calculation to exclude pending add_cash transactions

## Link to issue:  
https://github.com/MidwestAccessCoalition/lockbox_rails/issues/183

## Steps for QA/Special Notes:
- Automated tests exist for pending vs completed add cash 
- To manually QA...
  - add cash to a lockbox
  - observe the balance staying the same
  - log in as a partner
  - confirm the cash deposit
  - watch the balance increase

## Relevant Screenshots: 
N/A

## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [ ] Added revelant screenshots
