### PR TITLE
Forms for user account editing & lockbox partner edits

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -7,6 +7,24 @@
   border-radius: 0px;
 }
 
-.form-group > label {
+.form-group > label, .field_with_errors > label {
   font-weight: bolder;
+}
+
+.field_with_errors {
+  display: inline-block;
+}
+
+#error_explanation {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+  padding: 1rem 1rem 0 1rem;
+  border: solid 1px transparent;
+  border-radius: 0.25rem;
+  margin: 1em 0;
+
+  h2 {
+    font-size: 14px;
+  }
 }

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -11,8 +11,12 @@
   font-weight: bolder;
 }
 
+.field input {
+  display: block;
+}
+
 .field_with_errors {
-  display: inline-block;
+  display: block;
 }
 
 #error_explanation {

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -57,3 +57,12 @@ header {
     margin-top: 0;
   }
 }
+
+nav a.edit_contact_info {
+  float: none;
+  display: inline-block;
+  width: auto;
+  margin-top: 1em;
+  font-size: 0.75em;
+  padding: 0.25em 2em;
+}

--- a/app/controllers/lockbox_partners_controller.rb
+++ b/app/controllers/lockbox_partners_controller.rb
@@ -1,6 +1,8 @@
 class LockboxPartnersController < ApplicationController
   before_action :set_lockbox_partner, except: [:new, :create]
-  before_action :require_admin_or_ownership, only: [:edit, :update]
+
+  before_action :require_admin, only: [:new, :create]
+  before_action :require_admin_or_ownership, only: [:show, :edit, :update]
 
   def new
     @lockbox_partner = LockboxPartner.new
@@ -12,7 +14,7 @@ class LockboxPartnersController < ApplicationController
   def create
     @lockbox_partner = LockboxPartner.new(lockbox_params)
     if @lockbox_partner.save
-      redirect_to '/', notice: 'Lockbox Partner was successfully created.'
+      redirect_to @lockbox_partner, notice: 'Lockbox Partner was successfully created.'
     else
       render :new
     end

--- a/app/controllers/lockbox_partners_controller.rb
+++ b/app/controllers/lockbox_partners_controller.rb
@@ -1,8 +1,12 @@
 class LockboxPartnersController < ApplicationController
-  before_action :require_admin, except: [:show]
+  before_action :set_lockbox_partner, except: [:new, :create]
+  before_action :require_admin_or_ownership, only: [:edit, :update]
 
   def new
     @lockbox_partner = LockboxPartner.new
+  end
+
+  def edit
   end
 
   def create
@@ -14,8 +18,15 @@ class LockboxPartnersController < ApplicationController
     end
   end
 
+  def update
+    if @lockbox_partner.update(lockbox_params)
+      redirect_to @lockbox_partner, notice: 'Contact information was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
   def show
-    @lockbox_partner = LockboxPartner.find(params[:id])
     require_admin_or_ownership
   end
 
@@ -25,5 +36,9 @@ class LockboxPartnersController < ApplicationController
     params.require(:lockbox_partner)
           .permit(:name, :phone_number, :street_address,
                   :city, :state, :zip_code)
+  end
+
+  def set_lockbox_partner
+    @lockbox_partner = LockboxPartner.find(params[:id])
   end
 end

--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -2,6 +2,9 @@ class LockboxPartner < ApplicationRecord
   has_many :users
   has_many :lockbox_actions
 
+  validates :name, presence: true
+  validates :phone_number, presence: true
+
   # Number of days since last reconciliation when clinic user will be prompted
   # to reconcile the lockbox. TODO make this configurable (issue #138)
   RECONCILIATION_INTERVAL = 30

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,12 +10,12 @@
   <% end %>
 
   <div class="field form-group">
-    <%= f.label :current_password %><br />
+    <%= f.label :current_password %>
     <%= f.password_field :current_password, autocomplete: "off" %>
   </div>
 
   <div class="field form-group">
-    <%= f.label :password, "New Password" %><br />
+    <%= f.label :password, "New Password" %>
     <% if @minimum_password_length %>
       <em><%= @minimum_password_length %> characters minimum</em>
       <br />
@@ -24,7 +24,7 @@
   </div>
 
   <div class="field form-group">
-    <%= f.label :password_confirmation, "Re-enter Password" %><br />
+    <%= f.label :password_confirmation, "Re-enter Password" %>
     <%= f.password_field :password_confirmation, autocomplete: "off" %>
   </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,46 +1,34 @@
-<div>
-  <h2>Account</h2>
-</div>
-
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= devise_error_messages! %>
 
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name %>
-  </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  <div>
+    <h2>Update Password</h2>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+  <div class="field form-group">
+    <%= f.label :current_password %><br />
     <%= f.password_field :current_password, autocomplete: "off" %>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Update" %>
+  <div class="field form-group">
+    <%= f.label :password, "New Password" %><br />
+    <% if @minimum_password_length %>
+      <em><%= @minimum_password_length %> characters minimum</em>
+      <br />
+    <% end %>
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <div class="field form-group">
+    <%= f.label :password_confirmation, "Re-enter Password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions form-group">
+    <%= f.submit "Update Password", class: "btn btn-primary" %>
   </div>
 <% end %>
-
-<%= link_to "Back", :back %>

--- a/app/views/layouts/_nav_bar.html.erb
+++ b/app/views/layouts/_nav_bar.html.erb
@@ -19,7 +19,7 @@
         <span>Log Out</span>
       <% end %>
       <%= link_to(edit_user_registration_path, class: 'btn btn-primary btn-invert') do %>
-        <span>Account Settings</span>
+        <span>Update Password</span>
       <% end %>
       <% if current_user.admin? %>
         <p>Quick Actions</p>

--- a/app/views/layouts/_nav_bar.html.erb
+++ b/app/views/layouts/_nav_bar.html.erb
@@ -26,6 +26,12 @@
         <p><a href="<%= lockbox_partners_path %>">View all lockboxes</a></p>
         <p><a href="<%= support_requests_new_path %>">File a support request</a></p>
         <p><a href="<%= new_lockbox_partner_path %>">Add a new lockbox partner</a></p>
+      <% elsif lp = current_user.lockbox_partner %>
+        <h2><%= lp.name %></h2>
+        <p><%= lp.street_address %></p>
+        <p><%= lp.city %>, <%= lp.state %> <%= lp.zip_code %></p>
+        <p><%= lp.phone_number %></p>
+        <p><%= link_to "Edit Contact Information", edit_lockbox_partner_path(lp), class: "edit_contact_info btn btn-primary btn-invert" %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/lockbox_partners/edit.html.erb
+++ b/app/views/lockbox_partners/edit.html.erb
@@ -1,0 +1,44 @@
+<div class="container">
+  <%= form_for @lockbox_partner, html: { class: 'form' } do |f| %>
+    <% if @lockbox_partner.errors.any? %>
+      <div id="error_explanation">
+        <h2>
+          <%= @lockbox_partner.errors.count %> error prohibited this user from being saved:
+        </h2>
+        <ul>
+          <% @lockbox_partner.errors.full_messages.each do |error_message| %>
+            <li><%= error_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <h2>Update Contact Information</h2>
+
+    <div class="form-group">
+      <%= f.label :name %>
+      <%= f.text_field :name, class: 'form-control' %>
+    </div>
+    <div class="form-group">
+      <%= f.label :street_address %>
+      <%= f.text_field :street_address, class: 'form-control'  %>
+    </div>
+    <div class="form-group">
+      <%= f.label :city %>
+      <%= f.text_field :city, class: 'form-control'  %>
+    </div>
+    <div class="form-group">
+      <%= f.label :state %>
+      <%= f.text_field :state, class: 'form-control'  %>
+    </div>
+    <div class="form-group">
+      <%= f.label :zip_code %>
+      <%= f.text_field :zip_code, class: 'form-control'  %>
+    </div>
+    <div class="form-group">
+      <%= f.label :phone_number %>
+      <%= f.text_field :phone_number, class: 'form-control'  %>
+    </div>
+    <%= f.submit 'Update Contact Information', class: 'btn btn-primary' %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   match 'support_requests/new', to: 'lockbox_partners/support_requests#new', via: [:get]
   resources :support_requests, only: [:index, :create]
 
-  resources :lockbox_partners, only: [:new, :create, :show] do
+  resources :lockbox_partners, only: [:new, :create, :show, :edit, :update] do
     scope module: 'lockbox_partners' do
       resources :users, only: [:new, :create]
       resources :support_requests, except: [:index, :destroy] do

--- a/spec/controllers/lockbox_partners_controller_spec.rb
+++ b/spec/controllers/lockbox_partners_controller_spec.rb
@@ -31,6 +31,45 @@ describe LockboxPartnersController do
     end
   end
 
+  describe "#create" do
+    let(:user_lockbox_partner) { nil }
+
+    before do
+      @lockbox_partner_count = LockboxPartner.count
+      sign_in(user)
+      post :create, params: {
+        lockbox_partner: {
+          name: "new partner",
+          phone_number: "555-555-5556"
+        }
+      }
+    end
+
+    context "when the user is an admin" do
+      let(:user_role) { User::ADMIN }
+
+      it "creates a lockbox partner" do
+        expect(LockboxPartner.count).to eq( @lockbox_partner_count + 1 )
+      end
+
+      it "redirects to the new partner" do
+        expect(response).to redirect_to(lockbox_partner_path(LockboxPartner.last))
+      end
+    end
+
+    context "when the user is not an admin" do
+      let(:user_role) { User::PARTNER }
+
+      it "returns 302" do
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "does not create a lockbox partner" do
+        expect(LockboxPartner.count).to eq(@lockbox_partner_count)
+      end
+    end
+  end
+
   describe "show" do
     before do
       sign_in(user)
@@ -52,6 +91,88 @@ describe LockboxPartnersController do
 
       it "returns 200" do
         expect(response.status).to eq(200)
+      end
+    end
+
+    context "when the user is not an admin and doesn't belong to the lockbox" do
+      let(:user_role) { User::PARTNER }
+      let(:user_lockbox_partner) { unauthorized_lockbox_partner }
+
+      it "returns 302" do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "#edit" do
+    before do
+      sign_in(user)
+      get :edit, params: { id: authorized_lockbox_partner.id }
+    end
+
+    context "when the user is an admin" do
+      let(:user_role) { User::ADMIN }
+      let(:user_lockbox_partner) { nil }
+
+      it "returns 200" do
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when the user is not an admin but a lockbox owner" do
+      let(:user_role) { User::PARTNER }
+      let(:user_lockbox_partner) { authorized_lockbox_partner }
+
+      it "returns 200" do
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when the user is not an admin and doesn't belong to the lockbox" do
+      let(:user_role) { User::PARTNER }
+      let(:user_lockbox_partner) { unauthorized_lockbox_partner }
+
+      it "returns 302" do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "#update" do
+    before do
+      @new_name = authorized_lockbox_partner.name + SecureRandom.uuid
+      sign_in(user)
+      put :update, params: { 
+        id: authorized_lockbox_partner.id,
+        lockbox_partner: {
+          name: @new_name
+        }
+      }
+    end
+
+    context "when the user is an admin" do
+      let(:user_role) { User::ADMIN }
+      let(:user_lockbox_partner) { nil }
+
+      it "updates the partner" do
+        expect(authorized_lockbox_partner.reload.name).to eq(@new_name)
+      end
+
+      it "redirects to the partner" do
+        expect(response).to redirect_to(lockbox_partner_path(authorized_lockbox_partner))
+      end
+    end
+
+    context "when the user is not an admin but a lockbox owner" do
+      let(:user_role) { User::PARTNER }
+      let(:user_lockbox_partner) { authorized_lockbox_partner }
+
+      it "updates the partner" do
+        expect(authorized_lockbox_partner.reload.name).to eq(@new_name)
+      end
+
+      it "redirects to the partner" do
+        expect(response).to redirect_to(lockbox_partner_path(authorized_lockbox_partner))
       end
     end
 


### PR DESCRIPTION
## Changelog
- Ability for lockbox partners to edit their contact info
- Ability for users to change their password (but nothing else about their account)
- Update nav to include links for these actions
- Update nav to include partner contact info when logged in as a partner

## Link to issue:  
Fixes issue #196 

## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 

New nav for partners:

<img width="1439" alt="LockboxRails" src="https://user-images.githubusercontent.com/608232/66709202-fc5bf000-ed24-11e9-9acd-13bb660d396c.png">

## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
