### PR TITLE
Add sign on amount #151

### DIFF
--- a/app/models/lockbox_action.rb
+++ b/app/models/lockbox_action.rb
@@ -126,6 +126,14 @@ class LockboxAction < ApplicationRecord
     end
   end
 
+  def credit?
+    lockbox_transactions.first&.balance_effect == LockboxTransaction::CREDIT
+  end
+
+  def debt?
+    lockbox_transactions.first&.balance_effect == LockboxTransaction::DEBIT
+  end
+
   private
 
   def inherit_lockbox_partner_id

--- a/app/models/lockbox_action.rb
+++ b/app/models/lockbox_action.rb
@@ -130,7 +130,7 @@ class LockboxAction < ApplicationRecord
     lockbox_transactions.first&.balance_effect == LockboxTransaction::CREDIT
   end
 
-  def debt?
+  def debit?
     lockbox_transactions.first&.balance_effect == LockboxTransaction::DEBIT
   end
 

--- a/app/views/dashboard/_admin_dash.html.erb
+++ b/app/views/dashboard/_admin_dash.html.erb
@@ -21,7 +21,7 @@
             <td>
               <% if action.credit? %>
                 +
-              <% elsif action.debt? %>
+              <% elsif action.debit? %>
                 -
               <% end %>
               <%= action.amount %>

--- a/app/views/dashboard/_admin_dash.html.erb
+++ b/app/views/dashboard/_admin_dash.html.erb
@@ -18,7 +18,14 @@
             <td><%= action.action_type.humanize %></td>
             <td><%= action.status %></td>
             <td><%= action.support_request&.name_or_alias %></td>
-            <td><%= action.amount %></td>
+            <td>
+              <% if action.credit? %>
+                +
+              <% elsif action.debt? %>
+                -
+              <% end %>
+              <%= action.amount %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/lockbox_partners/show.html.erb
+++ b/app/views/lockbox_partners/show.html.erb
@@ -19,7 +19,14 @@
               <td><%= action.eff_date %></td>
               <td><%= action.action_type.humanize %></td>
               <td><%= action.status %></td>
-              <td><%= action.amount %></td>
+              <td>
+                <% if action.credit? %>
+                  +
+                <% elsif action.debt? %>
+                  -
+                <% end %>
+                <%= action.amount %>
+              </td>
               <td><%= action.support_request&.name_or_alias %></td>
               <td>
                 <% if action.support_request %>

--- a/app/views/lockbox_partners/show.html.erb
+++ b/app/views/lockbox_partners/show.html.erb
@@ -22,7 +22,7 @@
               <td>
                 <% if action.credit? %>
                   +
-                <% elsif action.debt? %>
+                <% elsif action.debit? %>
                   -
                 <% end %>
                 <%= action.amount %>


### PR DESCRIPTION
## Changelog
- What did you do (high level bullet points)?
>all debit amounts are prepended with a minus sign (we expect all support requests and some reconciliation adjustments to be debits)
>all credit amounts are prepended with a plus sign (we expect all add cash and some reconciliation lockbox actions to be credits)

## Link to issue:  
Fixes issue #151 


## Steps for QA/Special Notes:
- "Reconcile" Is saving amount as negative value
Steps to reproduce - 
1. click "Reconcile" on Action needed 
2. Enter amount smaller than Add Cash amount


## Relevant Screenshots: 
- super important for UI tasks!
<img width="1048" alt="Screen Shot 2019-10-13 at 6 21 10 PM" src="https://user-images.githubusercontent.com/34173394/66724062-95067480-ede6-11e9-8b23-bacc4e8ecd2a.png">

<img width="638" alt="Screen Shot 2019-10-15 at 3 36 03 PM" src="https://user-images.githubusercontent.com/34173394/66867916-eab35c00-ef61-11e9-9463-345e67d4d0c8.png">


## Are you ready for review?:

~Added relevant tests~
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
