### PR TITLE
Grey out background of row for canceled actions

### DIFF
--- a/app/assets/stylesheets/lockbox_activity.scss
+++ b/app/assets/stylesheets/lockbox_activity.scss
@@ -14,5 +14,5 @@
 }
 
 tr.canceled {
-  background-color: $grey-background;
+  font-style: italic;
 }

--- a/app/assets/stylesheets/lockbox_activity.scss
+++ b/app/assets/stylesheets/lockbox_activity.scss
@@ -12,3 +12,7 @@
 .lockbox-activity > p {
   margin: 40px 0;
 }
+
+tr.canceled {
+  background-color: $grey-background;
+}

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -11,3 +11,4 @@ $darker-blue: #194180;
 $gray: #dee2e6;
 $medium-dark-gray: rgb(207,208,210);
 $light-gray: rgb(247,247,247);
+$grey-background: #A4A4A4;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -11,4 +11,3 @@ $darker-blue: #194180;
 $gray: #dee2e6;
 $medium-dark-gray: rgb(207,208,210);
 $light-gray: rgb(247,247,247);
-$grey-background: #A4A4A4;

--- a/app/views/dashboard/_admin_dash.html.erb
+++ b/app/views/dashboard/_admin_dash.html.erb
@@ -12,8 +12,9 @@
     <table class="table table-no-border">
       <tbody>
         <% lockbox_partner.historical_actions.each do |action| %>
-          <% support_request_class = action.support_request ? 'support-request' : '' %>
-          <tr class=<%= support_request_class %>>
+          <% support_request_class = action.support_request ? 'support-request ' : '' %>
+          <% row_class = support_request_class + action.status %>
+          <tr class="<%= row_class %>">
             <td><%= action.eff_date %></td>
             <td><%= action.action_type.humanize %></td>
             <td><%= action.status %></td>

--- a/app/views/lockbox_partners/show.html.erb
+++ b/app/views/lockbox_partners/show.html.erb
@@ -15,7 +15,7 @@
         </thead>
         <tbody>
           <% @lockbox_partner.historical_actions.each do |action| %>
-            <tr>
+            <tr class=<%= action.status %>>
               <td><%= action.eff_date %></td>
               <td><%= action.action_type.humanize %></td>
               <td><%= action.status %></td>


### PR DESCRIPTION
## Changelog
- What did you do (high level bullet points)?
>all lockbox actions in canceled status should be greyed out (hex value #A4A4A4), but retain the ability to view details

## Link to issue:  
Fixes issue #151

## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
<img width="592" alt="Screen Shot 2019-10-15 at 7 37 53 PM" src="https://user-images.githubusercontent.com/34173394/66879551-337c0c80-ef84-11e9-87af-82737069e9eb.png">
<img width="1083" alt="Screen Shot 2019-10-15 at 7 20 53 PM" src="https://user-images.githubusercontent.com/34173394/66879556-37a82a00-ef84-11e9-8da3-cbb7553f28c1.png">

## Are you ready for review?:

~Added relevant tests~
- [x] Linked PR to the issue
~Added notes for QA/special notes~
- [x] Added revelant screenshots
