### PR TITLE
fix negative recon amounts

### DIFF
--- a/app/models/lockbox_transaction.rb
+++ b/app/models/lockbox_transaction.rb
@@ -5,6 +5,8 @@ class LockboxTransaction < ApplicationRecord
 
   belongs_to :lockbox_action
 
+  validates :amount_cents, :numericality => { :greater_than_or_equal_to => 0 }
+
   BALANCE_EFFECTS = [
     DEBIT  = 'debit',
     CREDIT = 'credit'

--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -29,7 +29,7 @@ class Reconciliation
         difference = amount - expected_amount
 
         lockbox_transaction = lockbox_action.lockbox_transactions.create!(
-          amount: difference,
+          amount: difference.abs,
           balance_effect: balance_effect(difference)
         )
 

--- a/spec/lib/reconciliation_spec.rb
+++ b/spec/lib/reconciliation_spec.rb
@@ -30,6 +30,32 @@ describe Reconciliation do
         .and_return(Monetize.parse('1000.00'))
     end
 
+    context 'when the amount is less than lockbox balance' do
+      let(:amount) { Money.new(900_00) }
+
+      it 'creates one lockbox action' do
+        expect{reconcile}.to change(LockboxAction, :count).by(1)
+      end
+
+      it 'creates the lockbox action with the correct attributes' do
+        lockbox_action = reconcile.value
+        expect(lockbox_action.lockbox_partner_id).to eq(lockbox_partner.id)
+        expect(lockbox_action.action_type).to eq(LockboxAction::RECONCILE)
+        expect(lockbox_action.status).to eq(LockboxAction::COMPLETED)
+      end
+
+      it 'creates one lockbox transaction' do
+        expect{reconcile}.to change(LockboxTransaction, :count).by(1)
+      end
+
+      it 'creates the lockbox transaction with the correct attributes' do
+        lockbox_transaction = reconcile.value.lockbox_transactions.first
+        expect(lockbox_transaction.eff_date).to eq(Date.current)
+        expect(lockbox_transaction.amount).to eq(Monetize.parse('100.00'))
+        expect(lockbox_transaction.balance_effect).to eq(LockboxTransaction::DEBIT)
+      end
+    end
+
     it 'creates one lockbox action' do
       expect{reconcile}.to change(LockboxAction, :count).by(1)
     end

--- a/spec/lib/reconciliation_spec.rb
+++ b/spec/lib/reconciliation_spec.rb
@@ -30,7 +30,7 @@ describe Reconciliation do
         .and_return(Monetize.parse('1000.00'))
     end
 
-    context 'when the amount is less than lockbox balance' do
+    context 'when the actual counted amount is less than the expected lockbox balance' do
       let(:amount) { Money.new(900_00) }
 
       it 'creates one lockbox action' do


### PR DESCRIPTION
Open a PR and fill out the template later!


## Changelog
- added validation for lockbox_transaction to never be below zero
- Set Reconciliation to always post absolute value of the difference when creating a lockbox_transaction

## Link to issue:  
Fixes issue https://github.com/MidwestAccessCoalition/lockbox_rails/issues/140


## Steps for QA/Special Notes:
- This bug would occur when the recon amount was less than the current amount in the lockbox, it would then create negaitve lockbox_transactions which resulted in most calculations being incorrect.

## Relevant Screenshots: 
- super important for UI tasks!


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
