### PR TITLE
Support request note notification 211

### DIFF
--- a/app/mailers/support_request_mailer.rb
+++ b/app/mailers/support_request_mailer.rb
@@ -1,9 +1,6 @@
 class SupportRequestMailer < ApplicationMailer
   def creation_alert
     @support_request = params[:support_request]
-
-    return if partner_user_emails.empty?
-
     urgency_flag_prefix = if @support_request.urgency_flag.present?
       "#{@support_request.urgency_flag} - "
     else
@@ -45,5 +42,10 @@ class SupportRequestMailer < ApplicationMailer
       .users
       .confirmed
       .pluck(:email)
+    if @partner_user_emails.empty?
+      raise ArgumentError, "Attempted to alert users for "\
+        "#{@support_request.lockbox_partner.name}, but none exist"
+    end
+    @partner_user_emails
   end
 end

--- a/app/mailers/support_request_mailer.rb
+++ b/app/mailers/support_request_mailer.rb
@@ -24,14 +24,17 @@ class SupportRequestMailer < ApplicationMailer
       raise ArgumentError, "This note is not associated with a support request"
     end
 
-    return if partner_user_emails.empty?
     subject = "A new note was added to Support Request ##{@support_request.id}"
     coordinator_emails = [@support_request.user.email, @note.user.email].uniq
-    mail(
-      to: partner_user_emails,
-      subject: subject,
-      cc: coordinator_emails
-    )
+    # If a coordinator creates the note, email the partner users and CC the
+    # coordinator(s). If a partner user creates it, do the reverse
+    to_emails, cc_emails = if @note.user.admin?
+      [partner_user_emails, coordinator_emails]
+    else
+      [coordinator_emails, partner_user_emails]
+    end
+
+    mail(to: to_emails, subject: subject, cc: cc_emails)
   end
 
   private

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -3,11 +3,24 @@ class Note < ApplicationRecord
   belongs_to :user, optional: true
   validates :text, presence: true
 
+  after_create :notify_partner, if: :should_notify_partner?
+
   def author
     if user
       user.name || "User #{user.id}"
     else
       "System Generated"
     end
+  end
+
+  private
+
+  def notify_partner
+    SupportRequestMailer.with(note: self).note_creation_alert.deliver_now
+  end
+
+  def should_notify_partner?
+    # Do not send email for system-generated notes (at least for now)
+    !!user && notable.is_a?(SupportRequest)
   end
 end

--- a/app/views/support_request_mailer/note_creation_alert.html.erb
+++ b/app/views/support_request_mailer/note_creation_alert.html.erb
@@ -1,5 +1,5 @@
 <h1>
-  A new note was added to Support Request #<%= @support_request.id %>
+  A new note was added to Support Request #<%= @support_request.id %> (pick-up date: <%= @support_request.pickup_date %>)
 </h1>
 <p>
   View the note here: <%= lockbox_partner_support_request_url(@support_request.lockbox_partner, @support_request) %>

--- a/app/views/support_request_mailer/note_creation_alert.html.erb
+++ b/app/views/support_request_mailer/note_creation_alert.html.erb
@@ -1,0 +1,6 @@
+<h1>
+  A new note was added to Support Request #<%= @support_request.id %>
+</h1>
+<p>
+  View the note here: <%= lockbox_partner_support_request_url(@support_request.lockbox_partner, @support_request) %>
+</p>

--- a/app/views/support_request_mailer/note_creation_alert.html.erb
+++ b/app/views/support_request_mailer/note_creation_alert.html.erb
@@ -1,5 +1,5 @@
 <h1>
-  A new note was added to Support Request #<%= @support_request.id %> (pick-up date: <%= @support_request.pickup_date %>)
+  A new note was added to Support Request #<%= @support_request.id %> (pick-up date: <%= @support_request.pickup_date.strftime("%B %d, %Y") %>)
 </h1>
 <p>
   View the note here: <%= lockbox_partner_support_request_url(@support_request.lockbox_partner, @support_request) %>

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :note do
     text    { Faker::Lorem.paragraph }
     association :notable, factory: :user
+    association :user
   end
 end

--- a/spec/models/notes_spec.rb
+++ b/spec/models/notes_spec.rb
@@ -2,4 +2,61 @@ require 'rails_helper'
 
 describe Note, type: :model do
   it { is_expected.to belong_to(:notable) }
+  it { is_expected.to belong_to(:user).optional }
+
+  context "callbacks" do
+    let(:note) { FactoryBot.build(:note, user: user, notable: notable) }
+
+    describe "email alert" do
+      let(:delivery) do
+        instance_double(
+          ActionMailer::Parameterized::MessageDelivery,
+          deliver_now: nil
+        )
+      end
+
+      let(:mailer) { double(note_creation_alert: delivery) }
+
+      before do
+        allow(SupportRequestMailer).to receive(:with).and_return(mailer)
+        note.save
+      end
+
+      context "when the note is not system-generated and belongs to a SupportRequest" do
+        let(:user) { FactoryBot.create(:user) }
+        let(:notable) { FactoryBot.create(:support_request) }
+
+        it "sends an email alert" do
+          expect(delivery).to have_received(:deliver_now)
+        end
+      end
+
+      context "when the note is system-generated and belongs to a SupportRequest" do
+        let(:user) { nil }
+        let(:notable) { FactoryBot.create(:support_request) }
+
+        it "does not send an email alert" do
+          expect(delivery).not_to have_received(:deliver_now)
+        end
+      end
+
+      context "when the note is not system-generated and does not belong to a SupportRequest" do
+        let(:user) { FactoryBot.create(:user) }
+        let(:notable) { FactoryBot.create(:user) }
+
+        it "does not send an email alert" do
+          expect(delivery).not_to have_received(:deliver_now)
+        end
+      end
+
+      context "when the note is system-generated and does not belong to a SupportRequest" do
+        let(:user) { nil }
+        let(:notable) { FactoryBot.create(:user) }
+
+        it "does not send an email alert" do
+          expect(delivery).not_to have_received(:deliver_now)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changelog
-  Added email alert when a non-system-generated note is added to a support request. Email is sent to confirmed users for the relevant partner, and CCs the creator of the note and the creator of the support request.

## Link to issue:  
Resolves #211 

## Steps for QA/Special Notes:
- Verify that email is sent when a note is created if it is (a) not system-created and (b) attached to a support request
- Verify that email is not sent if either condition is not met

## Relevant Screenshots: 
Example email:
```
Delivered mail 5db60eb61f614_1ce32b1623999b981038@kevin-asus.mail (2.9ms)
Date: Sun, 27 Oct 2019 16:40:06 -0500
From: from@example.com
To: fluffy@catsclinic.com
Cc: cats@test.com
Message-ID: <5db60eb61f614_1ce32b1623999b981038@kevin-asus.mail>
Subject: A new note was added to Support Request #1
Mime-Version: 1.0
Content-Type: text/html;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

<!DOCTYPE html>
<html>
  <head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
    <style>
      /* Email styles need to be inline */
    </style>
  </head>

  <body>
    <h1>
  A new note was added to Support Request #1
</h1>
<p>
  View the note here: http://localhost:3000/lockbox_partners/1/support_requests/1
</p>

  </body>
</html>
```

## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
