### PR TITLE
Add mailer specs 251

### DIFF
--- a/app/mailers/support_request_mailer.rb
+++ b/app/mailers/support_request_mailer.rb
@@ -25,12 +25,12 @@ class SupportRequestMailer < ApplicationMailer
     end
 
     subject = "A new note was added to Support Request ##{@support_request.id}"
-    coordinator_emails = [@support_request.user.email, @note.user.email].uniq
+    coordinator_emails = [@support_request.user.email]
     # If a coordinator creates the note, email the partner users and CC the
     # coordinator(s). If a partner user creates it, do the reverse
-    binding.pry
     to_emails, cc_emails = if @note.user.admin?
-      [partner_user_emails, coordinator_emails]
+      coordinator_emails << @note.user.email
+      [partner_user_emails, coordinator_emails.uniq]
     else
       [coordinator_emails, partner_user_emails]
     end

--- a/app/mailers/support_request_mailer.rb
+++ b/app/mailers/support_request_mailer.rb
@@ -28,6 +28,7 @@ class SupportRequestMailer < ApplicationMailer
     coordinator_emails = [@support_request.user.email, @note.user.email].uniq
     # If a coordinator creates the note, email the partner users and CC the
     # coordinator(s). If a partner user creates it, do the reverse
+    binding.pry
     to_emails, cc_emails = if @note.user.admin?
       [partner_user_emails, coordinator_emails]
     else

--- a/spec/factories/lockbox_partners.rb
+++ b/spec/factories/lockbox_partners.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     trait :active do
       # The user needs to be confirmed, but currently the user factory does this
       # by default
-      users { build_list :user, 1 }
+      users { build_list :user, 1, :partner_user }
       lockbox_actions { build_list :lockbox_action, 1, :add_cash, :completed }
     end
   end

--- a/spec/mailers/lockbox_partner_mailer_spec.rb
+++ b/spec/mailers/lockbox_partner_mailer_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe LockboxPartnerMailer, type: :mailer do
+  let(:lockbox_partner) { FactoryBot.create(:lockbox_partner, :active) }
+
+  describe "#low_balance_alert" do
+    let(:low_balance_alert_email) { "lowbalancealert@example.com" }
+
+    let(:email) do
+      described_class
+        .with(lockbox_partner: lockbox_partner)
+        .low_balance_alert
+        .deliver_now
+    end
+
+    before do
+      allow(ENV)
+        .to receive(:[])
+        .with("LOW_BALANCE_ALERT_EMAIL")
+        .and_return(low_balance_alert_email)
+    end
+
+    it "sends the email to the address specified in an env var" do
+      expect(email.to).to eq([low_balance_alert_email])
+    end
+
+    it "has the expected subject line" do
+      expect(email.subject).to eq(
+        "[LOW LOCKBOX BALANCE] #{lockbox_partner.name} needs cash"
+      )
+    end
+  end
+end

--- a/spec/mailers/lockbox_partner_mailer_spec.rb
+++ b/spec/mailers/lockbox_partner_mailer_spec.rb
@@ -16,6 +16,9 @@ describe LockboxPartnerMailer, type: :mailer do
     before do
       allow(ENV)
         .to receive(:[])
+        .and_call_original
+      allow(ENV)
+        .to receive(:[])
         .with("LOW_BALANCE_ALERT_EMAIL")
         .and_return(low_balance_alert_email)
     end
@@ -28,6 +31,12 @@ describe LockboxPartnerMailer, type: :mailer do
       expect(email.subject).to eq(
         "[LOW LOCKBOX BALANCE] #{lockbox_partner.name} needs cash"
       )
+    end
+
+    it "alerts the recipient to the low balance" do
+      alert_text = "The lockbox balance at <b>#{lockbox_partner.name}</b> is at " \
+                   "<b>$#{lockbox_partner.balance.to_s}</b>"
+      expect(email.body.encoded).to include(alert_text)
     end
   end
 end

--- a/spec/mailers/support_request_mailer_spec.rb
+++ b/spec/mailers/support_request_mailer_spec.rb
@@ -24,6 +24,22 @@ describe SupportRequestMailer, type: :model do
       expect(email.subject).to eq(expected_subject)
     end
 
+    context "when there are no confirmed partner users" do
+      let(:lockbox_partner) { FactoryBot.create(:lockbox_partner) }
+
+      it "raises an exception" do
+        expect{email}.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when the note does not belong to a support request" do
+      let(:support_request) { FactoryBot.create(:lockbox_action) }
+
+      it "raises an exception" do
+        expect{email}.to raise_error(ArgumentError)
+      end
+    end
+
     context "when an admin user creates the note" do
       it "sends the email to the lockbox partner's users" do
         expect(email.to).to eq(support_request.lockbox_partner.users.pluck(:email))

--- a/spec/mailers/support_request_mailer_spec.rb
+++ b/spec/mailers/support_request_mailer_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe SupportRequestMailer, type: :model do
+  describe "#note_creation_alert" do
+    let(:admin_user) { FactoryBot.create(:user) }
+    let(:lockbox_partner) { FactoryBot.create(:lockbox_partner, :active) }
+
+    let(:support_request) do
+      FactoryBot.create(
+        :support_request, :pending, lockbox_partner: lockbox_partner
+      )
+    end
+
+    let(:note) do
+      FactoryBot.create(:note, user: admin_user, notable: support_request)
+    end
+
+    let(:email) do
+      described_class.with(note: note).note_creation_alert.deliver_now
+    end
+
+    it "has the expected subject line" do
+      expected_subject = "A new note was added to Support Request ##{support_request.id}"
+      expect(email.subject).to eq(expected_subject)
+    end
+
+    context "when an admin user creates the note" do
+      it "sends the email to the lockbox partner's users" do
+        expect(email.to).to eq(support_request.lockbox_partner.users.pluck(:email))
+      end
+
+      it "CCs the note creator and support request creator" do
+        expect(email.cc).to eq([support_request.user.email, admin_user.email])
+      end
+    end
+
+    context "when a partner user creates the note" do
+      let(:note) do
+        FactoryBot.create(
+          :note, user: lockbox_partner.users.first, notable: support_request
+        )
+      end
+
+      let(:email) do
+        described_class.with(note: note).note_creation_alert.deliver_now
+      end
+
+      it "sends the email to the support request creator" do
+        expect(email.to).to eq(support_request.user.email)
+      end
+
+      it "CCs the lockbox partner's users" do
+        expect(email.cc).to eq(support_request.lockbox_partner.users.pluck(:email))
+      end
+    end
+  end
+end

--- a/spec/mailers/support_request_mailer_spec.rb
+++ b/spec/mailers/support_request_mailer_spec.rb
@@ -49,6 +49,28 @@ describe SupportRequestMailer, type: :mailer do
       expect(email.cc).to eq([support_request.user.email])
     end
 
+    context "body" do
+      it "includes the pickup date" do
+        expect(email.body.encoded).to include(
+          support_request.pickup_date.strftime("%A, %B %d, %Y")
+        )
+      end
+
+      it "includes the amount" do
+        expect(email.body.encoded).to include(support_request.amount.format)
+      end
+
+      it "includes the coordinator's name" do
+        expected_name = ERB::Util.html_escape(support_request.user.name)
+        expect(email.body.encoded).to include(expected_name)
+      end
+
+      it "includes a link to the support_request" do
+        path = "/lockbox_partners/#{lockbox_partner.id}/support_requests/#{support_request.id}"
+        expect(email.body.encoded).to include(path)
+      end
+    end
+
     context "when there are no confirmed partner users" do
       let(:lockbox_partner) { FactoryBot.create(:lockbox_partner) }
 
@@ -115,6 +137,17 @@ describe SupportRequestMailer, type: :mailer do
 
       it "CCs the lockbox partner's users" do
         expect(email.cc).to eq(support_request.lockbox_partner.users.pluck(:email))
+      end
+    end
+
+    context "body" do
+      it "includes the support request ID" do
+        expect(email.body.encoded).to include("##{support_request.id}")
+      end
+
+      it "includes a link to the support_request" do
+        path = "/lockbox_partners/#{lockbox_partner.id}/support_requests/#{support_request.id}"
+        expect(email.body.encoded).to include(path)
       end
     end
   end

--- a/spec/mailers/support_request_mailer_spec.rb
+++ b/spec/mailers/support_request_mailer_spec.rb
@@ -46,7 +46,7 @@ describe SupportRequestMailer, type: :model do
       end
 
       it "sends the email to the support request creator" do
-        expect(email.to).to eq(support_request.user.email)
+        expect(email.to).to eq([support_request.user.email])
       end
 
       it "CCs the lockbox partner's users" do


### PR DESCRIPTION
## Changelog
- Fixed a minor bug that caused a note creator's email to be included in `to` rather than `cc`
- Added mailer tests

## Link to issue:  
Fixes issue #251 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
- super important for UI tasks!


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added revelant screenshots
