### PR TITLE
Status change notification 187

### DIFF
--- a/app/controllers/lockbox_partners/support_requests_controller.rb
+++ b/app/controllers/lockbox_partners/support_requests_controller.rb
@@ -53,8 +53,13 @@ class LockboxPartners::SupportRequestsController < ApplicationController
     require_admin_or_ownership
 
     status = update_status_params[:status]
+    original_status = @support_request.status
     if @support_request.lockbox_action.update(status: status)
       flash[:notice] = "Status updated to #{status}"
+      @support_request.send_status_update_alert(
+        user: current_user,
+        original_status: original_status
+      )
     else
       flash[:error] = "Failed to update status"
     end

--- a/app/mailers/support_request_mailer.rb
+++ b/app/mailers/support_request_mailer.rb
@@ -44,7 +44,7 @@ class SupportRequestMailer < ApplicationMailer
     @original_status = params[:original_status]
     @date = params[:date].strftime("%B %d, %Y")
     subject = "#{@support_request.lockbox_partner.name} Support Request " \
-              "#{@support_request.id} - #{@support_request.status}"
+              "##{@support_request.id} - #{@support_request.status}"
     mail(
       to: @support_request.user.email,
       subject: subject

--- a/app/mailers/support_request_mailer.rb
+++ b/app/mailers/support_request_mailer.rb
@@ -38,6 +38,19 @@ class SupportRequestMailer < ApplicationMailer
     mail(to: to_emails, subject: subject, cc: cc_emails)
   end
 
+  def status_update_alert
+    @support_request = params[:support_request]
+    @user = params[:user]
+    @original_status = params[:original_status]
+    @date = params[:date].strftime("%B %d, %Y")
+    subject = "#{@support_request.lockbox_partner.name} Support Request " \
+              "#{@support_request.id} - #{@support_request.status}"
+    mail(
+      to: @support_request.user.email,
+      subject: subject
+    )
+  end
+
   private
 
   def partner_user_emails

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -76,6 +76,9 @@ class SupportRequest < ApplicationRecord
   end
 
   def send_status_update_alert(original_status:, user:)
+    # This likely means the status update was submitted twice. To avoid
+    # confusion, we shouldn't send the email in that case.
+    return if original_status == status
     date = Date.current
     SupportRequestMailer
       .with(

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -75,6 +75,18 @@ class SupportRequest < ApplicationRecord
     notes.create(text: note_text)
   end
 
+  def send_status_update_alert(original_status:, user:)
+    date = Date.current
+    SupportRequestMailer
+      .with(
+        original_status: original_status,
+        user: user,
+        date: date
+      )
+      .status_update_alert
+      .deliver_now
+  end
+
   private
 
   def index_in_support_requests_collection

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -79,9 +79,10 @@ class SupportRequest < ApplicationRecord
     date = Date.current
     SupportRequestMailer
       .with(
+        date: date,
         original_status: original_status,
-        user: user,
-        date: date
+        support_request: self,
+        user: user
       )
       .status_update_alert
       .deliver_now

--- a/app/views/support_request_mailer/status_update_alert.text.erb
+++ b/app/views/support_request_mailer/status_update_alert.text.erb
@@ -1,1 +1,1 @@
-<%= @support_request.lockbox_partner.name %> support request <%= @support_request.id %> was changed from <%= @original_status %> to <%= @support_request.status %> by <%= @user.name %> on <%= @date %>.
+<%= @support_request.lockbox_partner.name %> support request #<%= @support_request.id %> was changed from <%= @original_status %> to <%= @support_request.status %> by <%= @user.name %> on <%= @date %>.

--- a/app/views/support_request_mailer/status_update_alert.text.erb
+++ b/app/views/support_request_mailer/status_update_alert.text.erb
@@ -1,0 +1,1 @@
+<%= @support_request.lockbox_partner.name %> support request <%= @support_request.id %> was changed from <%= @original_status %> to <%= @support_request.status %> by <%= @user.name %> on <%= @date %>.

--- a/spec/mailers/support_request_mailer_spec.rb
+++ b/spec/mailers/support_request_mailer_spec.rb
@@ -151,4 +151,52 @@ describe SupportRequestMailer, type: :mailer do
       end
     end
   end
+
+  describe "#status_update_alert" do
+    let(:original_status) { "pending" }
+    let(:lockbox_partner) { FactoryBot.create(:lockbox_partner, :active) }
+    let(:date) { Date.current }
+
+    let(:user) do
+      FactoryBot.create(:user, :partner_user, lockbox_partner: lockbox_partner)
+    end
+
+    let(:support_request) do
+      FactoryBot.create(
+        :support_request,
+        :completed,
+        lockbox_partner: lockbox_partner
+      )
+    end
+
+    let(:email) do
+      described_class
+        .with(
+          date: date,
+          original_status: "pending",
+          support_request: support_request,
+          user: user
+        )
+        .status_update_alert
+        .deliver_now
+    end
+
+    it "emails the support request creator" do
+      expect(email.to).to eq([support_request.user.email])
+    end
+
+    it 'has the correct subject line' do
+      expected_subject = "#{support_request.lockbox_partner.name} Support " \
+                         "Request ##{support_request.id} - completed"
+      expect(email.subject).to include(expected_subject)
+    end
+
+    it "has the correct body" do
+      expected_body =
+        "#{support_request.lockbox_partner.name} support request " \
+        "##{support_request.id} was changed from pending to completed by " \
+        "#{user.name} on #{date.strftime("%B %d, %Y")}."
+      expect(email.body.encoded).to include(expected_body)
+    end
+  end
 end

--- a/spec/models/support_request_spec.rb
+++ b/spec/models/support_request_spec.rb
@@ -98,4 +98,63 @@ describe SupportRequest, type: :model do
       expect(results).not_to include(canceled_wrong_partner)
     end
   end
+
+  describe '#send_status_update_alert' do
+    let(:original_status) { 'pending' }
+    let(:lockbox_partner) { FactoryBot.create(:lockbox_partner, :active) }
+
+    let(:user) do
+      FactoryBot.create(:user, :partner_user, lockbox_partner: lockbox_partner)
+    end
+
+    let(:support_request) do
+      FactoryBot.create(
+        :support_request,
+        :completed,
+        lockbox_partner: lockbox_partner
+      )
+    end
+
+    let(:delivery) do
+      instance_double(
+        ActionMailer::Parameterized::MessageDelivery,
+        deliver_now: nil
+      )
+    end
+
+    let(:mailer) { double(status_update_alert: delivery) }
+
+    before do
+      allow(SupportRequestMailer).to receive(:with).and_return(mailer)
+      support_request.send_status_update_alert(
+        original_status: original_status,
+        user: user
+      )
+    end
+
+    context 'when the new status is different from the original status' do
+      it 'passes the correct params to the mailer' do
+        expect(SupportRequestMailer)
+          .to have_received(:with)
+          .with(
+            date: Date.current,
+            original_status: original_status,
+            support_request: support_request,
+            user: user
+          )
+      end
+
+      it 'sends the email' do
+        expect(delivery).to have_received(:deliver_now)
+      end
+    end
+
+    context 'when the new status is the same as the original status' do
+      let(:original_status) { 'completed' }
+
+      it 'does nothing' do
+        expect(SupportRequestMailer).not_to have_received(:with)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Open a PR and fill out the template later!


## Changelog
- Added email notification to MAC coordinator when a support request's status is updated

## Link to issue:  
Fixes #187 

## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
Example email

```
Date: Sun, 10 Nov 2019 17:17:42 -0600
From: from@example.com
To: cats@test.com
Message-ID: <5dc89a96eae82_209b2ae5dbba9f8c6487b@kevin-asus.mail>
Subject: Healthy Sloths Support Request 3 - completed
Mime-Version: 1.0
Content-Type: text/plain;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

Healthy Sloths support request #3 was changed from pending to completed by Sally Snake on November 10, 2019.
```

## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
