### PR TITLE
Do not render the entire flash hash

### DIFF
--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -13,7 +13,9 @@
       <div class="devise-form container">
         <div id="errors">
           <% flash.each do |key, value| %>
-            <%= render partial: 'shared/error', locals: { key: key, value: value } %>
+            <% if ["alert", "notice"].include?(key) %>
+              <%= render partial: 'shared/error', locals: { key: key, value: value } %>
+            <% end %>
           <% end %>
         </div>
         <%= yield %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -13,6 +13,8 @@
       <div class="devise-form container">
         <div id="errors">
           <% flash.each do |key, value| %>
+            <% # Only display Devise flash messages that are intended to be displayed, and not those used internally by Devise  %>
+            <% # See https://github.com/plataformatec/devise#configuring-controllers %>
             <% if ["alert", "notice"].include?(key) %>
               <%= render partial: 'shared/error', locals: { key: key, value: value } %>
             <% end %>


### PR DESCRIPTION
## Changelog
- Revised devise layout so that it only renders flash messages intended to be rendered

## Link to issue:  
Fixes #250 

## Steps for QA/Special Notes:
- This is easier to test if `config.timeout_in` is set to `1.minute` in `config/initializers/devise.rb`

## Relevant Screenshots: 
![Screenshot_20191110_183739](https://user-images.githubusercontent.com/8214544/68553747-8319f080-03e9-11ea-96f2-7616bfda8a79.png)


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
