### PR TITLE
Ensure that CreateSupportRequest doesn't leave DB in inconsistent state 262

### DIFF
--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -26,9 +26,9 @@ class LockboxPartner < ApplicationRecord
   def balance(exclude_pending: false)
     relevant_transactions_for_balance(exclude_pending: exclude_pending).inject(Money.zero) do |balance, action|
       case action.balance_effect
-      when 'credit'
+      when LockboxTransaction::CREDIT
         balance += action.amount
-      when 'debit'
+      when LockboxTransaction::DEBIT
         balance -= action.amount
       end
       balance

--- a/app/models/lockbox_transaction.rb
+++ b/app/models/lockbox_transaction.rb
@@ -5,7 +5,7 @@ class LockboxTransaction < ApplicationRecord
 
   belongs_to :lockbox_action
 
-  validates :amount_cents, :numericality => { :greater_than_or_equal_to => 0 }
+  validates :amount_cents, numericality: { greater_than: 0 }
   validates :category, presence: true
 
   BALANCE_EFFECTS = [

--- a/app/models/lockbox_transaction.rb
+++ b/app/models/lockbox_transaction.rb
@@ -14,13 +14,14 @@ class LockboxTransaction < ApplicationRecord
   ].freeze
 
   EXPENSE_CATEGORIES = [
-    GAS        = 'gas',
-    PARKING    = 'parking',
-    TRANSIT    = 'transit',
-    CHILDCARE  = 'childcare',
-    MEDICINE   = 'medicine',
-    FOOD       = 'food',
-    ADJUSTMENT = 'adjustment'
+    GAS           = 'gas',
+    PARKING       = 'parking',
+    TRANSIT       = 'transit',
+    CHILDCARE     = 'childcare',
+    MEDICINE      = 'medicine',
+    FOOD          = 'food',
+    ADJUSTMENT    = 'adjustment',
+    CASH_ADDITION = 'cash_addition'
   ].freeze
 
   def eff_date

--- a/app/models/lockbox_transaction.rb
+++ b/app/models/lockbox_transaction.rb
@@ -6,6 +6,7 @@ class LockboxTransaction < ApplicationRecord
   belongs_to :lockbox_action
 
   validates :amount_cents, :numericality => { :greater_than_or_equal_to => 0 }
+  validates :category, presence: true
 
   BALANCE_EFFECTS = [
     DEBIT  = 'debit',

--- a/lib/add_cash_to_lockbox.rb
+++ b/lib/add_cash_to_lockbox.rb
@@ -22,7 +22,8 @@ class AddCashToLockbox
 
       lockbox_transaction = lockbox_action.lockbox_transactions.create(
         amount: amount,
-        balance_effect: LockboxTransaction::CREDIT
+        balance_effect: LockboxTransaction::CREDIT,
+        category: 'gas'
       )
 
       unless lockbox_transaction.valid?

--- a/lib/add_cash_to_lockbox.rb
+++ b/lib/add_cash_to_lockbox.rb
@@ -23,7 +23,7 @@ class AddCashToLockbox
       lockbox_transaction = lockbox_action.lockbox_transactions.create(
         amount: amount,
         balance_effect: LockboxTransaction::CREDIT,
-        category: LockboxTransaction::ADJUSTMENT
+        category: LockboxTransaction::CASH_ADDITION
       )
 
       unless lockbox_transaction.valid?

--- a/lib/add_cash_to_lockbox.rb
+++ b/lib/add_cash_to_lockbox.rb
@@ -23,7 +23,7 @@ class AddCashToLockbox
       lockbox_transaction = lockbox_action.lockbox_transactions.create(
         amount: amount,
         balance_effect: LockboxTransaction::CREDIT,
-        category: 'gas'
+        category: LockboxTransaction::ADJUSTMENT
       )
 
       unless lockbox_transaction.valid?

--- a/lib/create_support_request.rb
+++ b/lib/create_support_request.rb
@@ -48,7 +48,7 @@ class CreateSupportRequest
       end
 
       params[:lockbox_action][:lockbox_transactions]
-        .select { |lt| lt[:amount] != "" }
+        .reject { |lt| lt[:amount].blank? && lt[:category].blank? }
         .each do |item|
           lockbox_transaction = lockbox_action.lockbox_transactions.create(
             amount:   item[:amount],

--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -30,7 +30,8 @@ class Reconciliation
 
         lockbox_transaction = lockbox_action.lockbox_transactions.create!(
           amount: difference.abs,
-          balance_effect: balance_effect(difference)
+          balance_effect: balance_effect(difference),
+          category: LockboxTransaction::ADJUSTMENT
         )
 
         unless lockbox_transaction.valid?

--- a/spec/factories/lockbox_transactions.rb
+++ b/spec/factories/lockbox_transactions.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     lockbox_action { build(:lockbox_action) }
 
     trait :for_add_cash do
-      balance_effect { 'credit' }
+      balance_effect { LockboxTransaction::CREDIT }
     end
   end
 end

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -4,8 +4,18 @@ require './lib/add_cash_to_lockbox'
 
 describe CreateSupportRequest do
   let(:mac_user) { FactoryBot.create(:user) }
+
   let(:lockbox_partner) do
     FactoryBot.create(:lockbox_partner, :active)
+  end
+
+  let(:lockbox_transactions) do
+    [
+      {
+        amount:       42.42,
+        category:     "gas"
+      }
+    ]
   end
 
   let(:params) do
@@ -16,34 +26,67 @@ describe CreateSupportRequest do
       lockbox_partner_id: lockbox_partner.id,
       lockbox_action: {
         eff_date:         Date.current,
-        lockbox_transactions: [
-          {
-            amount:       42.42,
-            category:     "gas"
-          }
-        ]
+        lockbox_transactions: lockbox_transactions
       },
       user_id:            mac_user.id,
     }
   end
 
+  subject { CreateSupportRequest.call(params: params) }
+
   it 'works' do
-    result = CreateSupportRequest.call(params: params)
+    result = subject
     expect(result).to be_success
     expect(result.value).to be_an_instance_of(SupportRequest)
   end
 
   it "creates a note" do
-    expect{CreateSupportRequest.call(params: params)}
-      .to change{Note.count}
-      .by(1)
+    expect{subject}.to change{Note.count}.by(1)
   end
 
   context "if creation of the lockbox action fails" do
     before { allow(LockboxAction).to receive(:create).and_return(LockboxAction.new) }
 
+    it "fails" do
+      expect(subject).not_to be_success
+    end
+
     it "does not create a support request" do
-      expect{CreateSupportRequest.call(params: params)}.not_to change(SupportRequest, :count)
+      expect{subject}.not_to change(SupportRequest, :count)
+    end
+  end
+
+  context "if no lockbox transactions are provided" do
+    let(:lockbox_transactions) { [] }
+
+    it "fails" do
+      expect(subject).not_to be_success
+    end
+
+    it "does not create a support request" do
+      expect{subject}.not_to change(SupportRequest, :count)
+    end
+  end
+
+  context "when one of the lockbox transactions is invalid" do
+    let(:lockbox_transactions) do
+      [
+        {
+          amount:   42.42,
+          category: "gas"
+        },
+        {
+          amount:   0.00
+        }
+      ]
+    end
+
+    it "fails" do
+      expect(subject).not_to be_success
+    end
+
+    it "does not create a support request" do
+      expect{subject}.not_to change(SupportRequest, :count)
     end
   end
 

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -90,6 +90,29 @@ describe CreateSupportRequest do
     end
   end
 
+  context "when one of the lockbox transactions is completely blank" do
+    let(:lockbox_transactions) do
+      [
+        {
+          amount:   42.42,
+          category: "gas"
+        },
+        {
+          amount:   "",
+          category: ""
+        }
+      ]
+    end
+
+    it "succeeds" do
+      expect(subject).to be_success
+    end
+
+    it "does not create a support request" do
+      expect{subject}.to change(SupportRequest, :count).by(1)
+    end
+  end
+
   context "partner notification email" do
     let(:delivery) do
       instance_double(

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -39,6 +39,14 @@ describe CreateSupportRequest do
       .by(1)
   end
 
+  context "if creation of the lockbox action fails" do
+    before { allow(LockboxAction).to receive(:create).and_return(LockboxAction.new) }
+
+    it "does not create a support request" do
+      expect{CreateSupportRequest.call(params: params)}.not_to change(SupportRequest, :count)
+    end
+  end
+
   context "partner notification email" do
     let(:delivery) do
       instance_double(

--- a/spec/models/lockbox_action_spec.rb
+++ b/spec/models/lockbox_action_spec.rb
@@ -37,7 +37,7 @@ describe LockboxAction, type: :model do
       FactoryBot.create(:lockbox_action, :support_client).tap do |action|
         action.lockbox_transactions.create(
           amount_cents: 20_00,
-          category: 'gas'
+          category: LockboxTransaction::GAS
         )
         action.lockbox_transactions.create(
           amount_cents: 20_00,

--- a/spec/models/lockbox_partner_spec.rb
+++ b/spec/models/lockbox_partner_spec.rb
@@ -14,7 +14,8 @@ describe LockboxPartner, type: :model do
     ).tap do |action|
       action.lockbox_transactions.create!(
         amount_cents: 1000_00,
-        balance_effect: 'credit'
+        balance_effect: 'credit',
+        category: LockboxTransaction::GAS
       )
     end
   end
@@ -28,7 +29,8 @@ describe LockboxPartner, type: :model do
       amount_breakdown.each do |amt_cents|
         lb_action.lockbox_transactions.create!(
           amount_cents: amt_cents,
-          balance_effect: 'debit'
+          balance_effect: 'debit',
+          category: LockboxTransaction::GAS
         )
       end
     end

--- a/spec/models/lockbox_partner_spec.rb
+++ b/spec/models/lockbox_partner_spec.rb
@@ -14,7 +14,7 @@ describe LockboxPartner, type: :model do
     ).tap do |action|
       action.lockbox_transactions.create!(
         amount_cents: 1000_00,
-        balance_effect: 'credit',
+        balance_effect: LockboxTransaction::CREDIT,
         category: LockboxTransaction::GAS
       )
     end
@@ -29,7 +29,7 @@ describe LockboxPartner, type: :model do
       amount_breakdown.each do |amt_cents|
         lb_action.lockbox_transactions.create!(
           amount_cents: amt_cents,
-          balance_effect: 'debit',
+          balance_effect: LockboxTransaction::DEBIT,
           category: LockboxTransaction::GAS
         )
       end


### PR DESCRIPTION
## Changelog
- Improved error handling in `CreateSupportRequest` action so that transaction is rolled back if any part of it fails
- Added validations to `LockboxTransaction`
- Ensured that transactions are always saved with a category
- Updated specs

## Link to issue:  
Fixes #262 

## Steps for QA/Special Notes:
- Tested support request creation (both through console and actual form) and verified that it still works

## Relevant Screenshots: 
- N/A

## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [ ] Added revelant screenshots
