### PR TITLE
System created notes should not be editable 249

### DIFF
--- a/app/controllers/lockbox_partners/notes_controller.rb
+++ b/app/controllers/lockbox_partners/notes_controller.rb
@@ -1,6 +1,7 @@
 class LockboxPartners::NotesController < ApplicationController
   before_action :find_commentable, only: %w[create]
   before_action :find_note, except: [:create]
+  before_action :ensure_not_system_created_note, only: [:edit, :update]
 
   def create
     @note = @commentable.notes.build(note_params.merge(user_id: current_user.id))
@@ -79,5 +80,12 @@ class LockboxPartners::NotesController < ApplicationController
 
   def find_note
     @note = Note.find(params[:id])
+  end
+
+  def ensure_not_system_created_note
+    unless @note.user
+      flash[:error] = "You are not authorized to access this page"
+      return redirect_to root_path
+    end
   end
 end

--- a/app/controllers/lockbox_partners/notes_controller.rb
+++ b/app/controllers/lockbox_partners/notes_controller.rb
@@ -85,7 +85,7 @@ class LockboxPartners::NotesController < ApplicationController
   def ensure_not_system_created_note
     unless @note.user
       flash[:error] = "You are not authorized to access this page"
-      return render status: 401, nothing: true
+      return render status: 401, body: nil
     end
   end
 end

--- a/app/controllers/lockbox_partners/notes_controller.rb
+++ b/app/controllers/lockbox_partners/notes_controller.rb
@@ -84,7 +84,6 @@ class LockboxPartners::NotesController < ApplicationController
 
   def ensure_not_system_created_note
     unless @note.user
-      flash[:error] = "You are not authorized to access this page"
       return render status: 401, body: nil
     end
   end

--- a/app/controllers/lockbox_partners/notes_controller.rb
+++ b/app/controllers/lockbox_partners/notes_controller.rb
@@ -85,7 +85,7 @@ class LockboxPartners::NotesController < ApplicationController
   def ensure_not_system_created_note
     unless @note.user
       flash[:error] = "You are not authorized to access this page"
-      return redirect_to root_path
+      return render status: 401, nothing: true
     end
   end
 end

--- a/app/views/lockbox_partners/notes/_note.html.erb
+++ b/app/views/lockbox_partners/notes/_note.html.erb
@@ -2,5 +2,11 @@
   <td><%= note.created_at.strftime('%Y/%m/%d %I:%M %p') %></td>
   <td><%= note.author %></td>
   <td><%= note.text %></td>
-  <td class="font-weight-bold"><a href="#" class="edit-note-button">Edit <%= fa_icon "arrow-right" %></a></td>
+  <td class="font-weight-bold">
+    <% if note.user %>
+      <a href="#" class="edit-note-button">
+        Edit <%= fa_icon "arrow-right" %>
+      </a>
+    <% end %>
+  </td>
 </tr>

--- a/spec/controllers/lockbox_partners/notes_controller_spec.rb
+++ b/spec/controllers/lockbox_partners/notes_controller_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+describe LockboxPartners::NotesController do
+  let(:lockbox_partner) { FactoryBot.create(:lockbox_partner, :active) }
+  let(:user) { FactoryBot.create(:user) }
+
+  let(:support_request) do
+    FactoryBot.create(
+      :support_request,
+      :pending,
+      lockbox_partner: lockbox_partner
+    )
+  end
+
+  let(:user_generated_note) do
+    FactoryBot.create(:note, notable: support_request, text: 'old text')
+  end
+
+  let(:system_generated_note) do
+    FactoryBot.create(
+      :note,
+      notable: support_request,
+      user: nil,
+      text: 'old text'
+    )
+  end
+
+  before { sign_in(user) }
+
+  describe '#edit' do
+    before do
+      get :edit, params: {
+        lockbox_partner_id: lockbox_partner.id,
+        support_request_id: support_request.id,
+        id: note.id
+      }
+    end
+
+    context 'when the note was system-generated' do
+      let(:note) { system_generated_note }
+
+      it 'returns 401' do
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'when the note was user-generated' do
+      let(:note) { user_generated_note }
+
+      it 'returns 200' do
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
+  describe '#update' do
+    before do
+      patch :update, params: {
+        lockbox_partner_id: lockbox_partner.id,
+        support_request_id: support_request.id,
+        id: note.id,
+        note: { text: 'new text' }
+      }
+    end
+
+    context 'when the note was system-generated' do
+      let(:note) { system_generated_note }
+
+      it 'returns 401' do
+        expect(response.status).to eq(401)
+      end
+
+      it 'does not update the text' do
+        expect(note.reload.text).to eq('old text')
+      end
+    end
+
+    context 'when the note was user-generated' do
+      let(:note) { user_generated_note }
+
+      it 'returns 200' do
+        expect(response.status).to eq(200)
+      end
+
+      it 'updates the text' do
+        expect(note.reload.text).to eq('new text')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changelog
- Removed the Edit link from the view for system-created notes
- Made the controller action return 401 if it is somehow called anyway

## Link to issue:  
Fixes #249 

## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
![Screenshot_20191124_163529](https://user-images.githubusercontent.com/8214544/69502829-38b06d80-0ed9-11ea-86a2-73227fc22124.png)


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
