### PR TITLE
Update support request dropdown styling 88

### DIFF
--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -131,6 +131,9 @@ $note-form-color: #d6d7d9;
     font-size: 1.5em;
     text-align: right;
   }
+  .icon-spacer {
+    margin-right: 1.25em;
+  }
 }
 
 .support-request-nav {

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -127,6 +127,10 @@ $note-form-color: #d6d7d9;
       }
     }
   }
+  .status-label {
+    font-size: 1.5em;
+    text-align: right;
+  }
 }
 
 .support-request-nav {

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -120,6 +120,14 @@ $note-form-color: #d6d7d9;
     margin: 0;
     width: 160px;
   }
+  .dropdown-menu {
+    border: 2px solid $color-primary;
+    border-radius: 0;
+    padding: 0;
+  }
+  .dropdown-item {
+    font-weight: bold;
+  }
   .row {
     div {
       p {

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -12,9 +12,6 @@
     margin: 10px;
     margin-top: 0px;
   }
-  a.btn-primary {
-    color: white;
-  }
   a.btn-primary.view-full {
     border: none;
     &:hover {

--- a/app/helpers/lockbox_partners_helper.rb
+++ b/app/helpers/lockbox_partners_helper.rb
@@ -2,4 +2,12 @@ module LockboxPartnersHelper
   def days_since_last_reconciliation
     (Date.current - @lockbox_partner.reconciliation_interval_start).to_i
   end
+
+  def status_display_text(status, support_request)
+    if status == support_request.status
+      (status.capitalize + " <i class='fa fa-check-circle'></i>").html_safe
+    else
+      status.capitalize
+    end
+  end
 end

--- a/app/helpers/lockbox_partners_helper.rb
+++ b/app/helpers/lockbox_partners_helper.rb
@@ -4,10 +4,11 @@ module LockboxPartnersHelper
   end
 
   def status_display_text(status, support_request)
-    if status == support_request.status
-      (status.capitalize + " <i class='fa fa-check-circle'></i>").html_safe
+    icon_html = if status == support_request.status
+      "<i class='fa fa-check'></i>"
     else
-      status.capitalize
+      "<i class='icon-spacer'></i>"
     end
+    (icon_html + " " + status.capitalize).html_safe
   end
 end

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -65,7 +65,7 @@ class SupportRequest < ApplicationRecord
   end
 
   def status_options
-    LockboxAction::STATUSES - [status]
+    LockboxAction::STATUSES
   end
 
   def record_creation

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -64,8 +64,12 @@ class SupportRequest < ApplicationRecord
     lockbox_action.status
   end
 
-  def status_options
-    LockboxAction::STATUSES
+  def status_options(include_current: false)
+    if include_current
+      LockboxAction::STATUSES
+    else
+      LockboxAction::STATUSES - status
+    end
   end
 
   def record_creation

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -68,7 +68,7 @@ class SupportRequest < ApplicationRecord
     if include_current
       LockboxAction::STATUSES
     else
-      LockboxAction::STATUSES - status
+      LockboxAction::STATUSES - [status]
     end
   end
 

--- a/app/views/lockbox_partners/support_requests/_coordinator_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_coordinator_status_dropdown.html.erb
@@ -1,0 +1,22 @@
+<div class="dropdown float-right">
+  <% if label %>
+    <p>Update Status</p>
+  <% end %>
+  <%= link_to '#', id: "dropdownMenuLink", :'data-toggle' => "dropdown", :'aria-haspopup' => true, :'aria-expanded' => false do %>
+    Update Status <i class="fa fa-angle-down"></i>
+  <% end %>
+  <p class="status-label">
+    <%= support_request.status.capitalize %>
+  </p>
+  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
+    <% support_request.status_options(include_current: true).each do |option| %>
+      <%= link_to status_display_text(option, support_request),
+        lockbox_partner_support_request_update_status_path(
+          support_request_id: support_request.id,
+          lockbox_partner_id: support_request.lockbox_partner_id,
+          status: option
+        ),
+        class: 'dropdown-item', method: 'post', remote: true %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/lockbox_partners/support_requests/_details_admin.html.erb
+++ b/app/views/lockbox_partners/support_requests/_details_admin.html.erb
@@ -1,6 +1,6 @@
 <div class="support-request-header">
   <% locals =  { support_request: @support_request, label: false } %>
-  <%= render partial: 'status_dropdown', locals: locals %>
+  <%= render partial: 'coordinator_status_dropdown', locals: locals %>
   <h3>Support Request for <%= @support_request.name_or_alias %></h3>
   <%= render partial: 'flag', locals: { support_request: @support_request } %>
 </div>

--- a/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
@@ -2,9 +2,15 @@
   <% if label %>
     <p>Update Status</p>
   <% end %>
-  <a class="btn btn-primary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <%= link_to '#', id: "dropdownMenuLink", :'data-toggle' => "dropdown", :'aria-haspopup' => true, :'aria-expanded' => false do %>
+    Update Status <i class="fa fa-angle-down"></i>
+  <% end %>
+  <p class="status-label">
     <%= support_request.status.capitalize %>
-  </a>
+  </p>
+  <!-- <a class="btn btn-primary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <%= support_request.status.capitalize %>
+  </a> -->
   <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
     <% support_request.status_options.each do |option| %>
       <%= link_to option.capitalize,

--- a/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
@@ -8,7 +8,7 @@
   <p class="status-label">
     <%= support_request.status.capitalize %>
   </p>
-  <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
     <% support_request.status_options.each do |option| %>
       <%= link_to status_display_text(option, support_request),
         lockbox_partner_support_request_update_status_path(

--- a/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
@@ -2,15 +2,12 @@
   <% if label %>
     <p>Update Status</p>
   <% end %>
-  <%= link_to '#', id: "dropdownMenuLink", :'data-toggle' => "dropdown", :'aria-haspopup' => true, :'aria-expanded' => false do %>
-    Update Status <i class="fa fa-angle-down"></i>
-  <% end %>
-  <p class="status-label">
+  <a class="btn btn-primary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <%= support_request.status.capitalize %>
-  </p>
-  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
+  </a>
+  <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
     <% support_request.status_options.each do |option| %>
-      <%= link_to status_display_text(option, support_request),
+      <%= link_to option.capitalize,
         lockbox_partner_support_request_update_status_path(
           support_request_id: support_request.id,
           lockbox_partner_id: support_request.lockbox_partner_id,

--- a/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
@@ -8,9 +8,6 @@
   <p class="status-label">
     <%= support_request.status.capitalize %>
   </p>
-  <!-- <a class="btn btn-primary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <%= support_request.status.capitalize %>
-  </a> -->
   <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
     <% support_request.status_options.each do |option| %>
       <%= link_to option.capitalize,

--- a/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
@@ -10,7 +10,7 @@
   </p>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
     <% support_request.status_options.each do |option| %>
-      <%= link_to option.capitalize,
+      <%= link_to status_display_text(option, support_request),
         lockbox_partner_support_request_update_status_path(
           support_request_id: support_request.id,
           lockbox_partner_id: support_request.lockbox_partner_id,

--- a/spec/system/support_request_actions_spec.rb
+++ b/spec/system/support_request_actions_spec.rb
@@ -38,4 +38,12 @@ RSpec.describe "Support Request Actions", type: :system do
     expect{ find_button("Save Note").click; sleep(1) }.to change { support_request.notes.last.text }.to("foobar")
   end
 
+  it "successfully change the status of a support request" do
+    visit "/lockbox_partners/#{lockbox_partner.id}/support_requests/#{support_request.id}"
+    click_link "Update Status"
+    click_link "Completed"
+    sleep(1)
+    assert_selector "p.status-label", text: "Completed"
+    expect(support_request.reload.status).to eq("completed")
+  end
 end


### PR DESCRIPTION
## Changelog
- Revised appearance of support request status dropdown for admin users

## Link to issue:  
Fixes #88 

## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
![Screenshot_20191201_183205](https://user-images.githubusercontent.com/8214544/69923365-dbcd2e00-1469-11ea-9940-ac7c2b9d2d4b.png)
![Screenshot_20191201_183423](https://user-images.githubusercontent.com/8214544/69923367-dd96f180-1469-11ea-9405-69b202c91c62.png)


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
