### PR TITLE
turn on paranoia

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -81,7 +81,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/spec/system/user_login_spec.rb
+++ b/spec/system/user_login_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe "User Login Flow", type: :system do
     email = ActionMailer::Base.deliveries.last
     expect(email.subject).to eq("Reset password instructions")
     expect(email.to.first).to eq(user.email)
-    assert_selector "div", text: "You will receive an email with instructions on how to reset your password in a few minutes."
+    assert_selector "div", text: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
   end
 end


### PR DESCRIPTION
## Changelog
- What did you do (high level bullet points)?

Turn on paranoid for devices so that error messages  display the same messages whether the email is taken or not.
## Link to issue:  
Fixes issue #232


## Steps for QA/Special Notes:
- Go through "forgot password" with an email that is not registered

## Relevant Screenshots: 
- super important for UI tasks!
<img width="665" alt="Screen Shot 2019-12-08 at 3 59 03 PM" src="https://user-images.githubusercontent.com/17070099/70397038-41726a80-19d4-11ea-8353-a8af90c824ab.png">


## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added revelant screenshots
