### PR TITLE
add sqreen gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'cocoon'
 # Add versions table for logging purposes
 gem 'paper_trail'
 
+gem 'sqreen', '>= 1.16'
+
 # TODO -- before we go live, should move this back to test/dev bundle
 # For test data generation
 gem 'factory_bot_rails', '~> 5.0', '>= 5.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
+    libsqreen (0.3.0.0.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -298,6 +299,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sq_mini_racer (0.2.5.0.1.beta2)
+    sqreen (1.18.3)
+      libsqreen (~> 0.3.0.0)
+      sq_mini_racer (~> 0.2.4.sqreen2)
     table_print (1.5.6)
     thor (1.0.1)
     thread_safe (0.3.6)
@@ -366,6 +371,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.0, >= 4.0.1)
   spring
   spring-watcher-listen (~> 2.0.0)
+  sqreen (>= 1.16)
   table_print
   turbolinks (~> 5.2, >= 5.2.1)
   tzinfo-data

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,4 +1,32 @@
+html,
+body {
+   margin:0;
+   padding:0;
+   height:100%;
+}
+
+.wrapper {
+  min-height:100%;
+  position:relative;
+}
+
 .main-content {
   margin-top: 40px;
   width: 90%;
+  padding-bottom:80px;
+}
+
+footer {
+  position:absolute;
+  bottom:0;
+  width:100%;
+  height:80px;
+  text-align: center;
+}
+
+#sqreen-badge {
+  display: inline-block;
+  img {
+    margin: 20px auto;
+  }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,14 +11,19 @@
   </head>
 
   <body>
-    <%= render 'layouts/header' %>
-    <div class="container" id="errors">
-      <% flash.each do |key, value| %>
-        <%= render partial: 'shared/error', locals: { key: key, value: value } %>
-      <% end %>
-    </div>
-    <div class="container main-content">
-      <%= yield %>
+    <div class="wrapper">
+      <%= render 'layouts/header' %>
+      <div class="container" id="errors">
+        <% flash.each do |key, value| %>
+          <%= render partial: 'shared/error', locals: { key: key, value: value } %>
+        <% end %>
+      </div>
+      <div class="container main-content">
+        <%= yield %>
+      </div>
+      <footer>
+        <a id="sqreen-badge" title="Realtime application protection" href="https://www.sqreen.com/?utm_source=badge"><img style="width:109px;height:36px" src="https://s3-eu-west-1.amazonaws.com/sqreen-assets/badges/20171107/sqreen-light-badge.svg" alt="Sqreen | Runtime Application Protection" /></a>
+      </footer>
     </div>
   </body>
 </html>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -21,6 +21,7 @@
           <% end %>
         </div>
         <%= yield %>
+        <a id="sqreen-badge" title="Realtime application protection" href="https://www.sqreen.com/?utm_source=badge"><img style="width:109px;height:36px" src="https://s3-eu-west-1.amazonaws.com/sqreen-assets/badges/20171107/sqreen-light-badge.svg" alt="Sqreen | Runtime Application Protection" /></a>
       </div>
     </div>
   </body>

--- a/config/sqreen.yml
+++ b/config/sqreen.yml
@@ -1,0 +1,2 @@
+app_name: "lockbox_rails"
+token: <%= ENV['SQREEN_TOKEN'] %>


### PR DESCRIPTION
## Changelog
- Set up Sqreen account for app monitoring
- Add sqreen config code
- Add env vars to prod
- Add Sqreen badge to site footer

## Link to issue:  
Part of setting up monitoring https://github.com/MidwestAccessCoalition/lockbox_rails/issues/302


## Steps for QA/Special Notes: 
- Sqreen has been set up to Block suspicious actions/IPs and to post alerts to Slack as well as email.

## Relevant Screenshots: 
In order to use Sqreen's service at the free open source tier, we need to add their badge to our site. This is how I've incorporated it...

![image](https://user-images.githubusercontent.com/5728859/72621263-e86cef00-390e-11ea-888e-49dba4f41e23.png)

![image](https://user-images.githubusercontent.com/5728859/72621278-f1f65700-390e-11ea-980a-cc58492ce7bc.png)


## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added revelant screenshots
