### PR TITLE
disable emails on staging environment using environment variable

### DIFF
--- a/app/mailers/note_mailer.rb
+++ b/app/mailers/note_mailer.rb
@@ -28,7 +28,7 @@ class NoteMailer < ApplicationMailer
 
     # Partner users get emailed about all notes
     users.concat(note.notable.try(:lockbox_partner).try(:users))
-    
+
     users.collect(&:email)
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "lockbox_rails_production"
 
-  config.action_mailer.delivery_method = ENV['DISABLE_PROD_EMAIL'] :test : :smtp
+  config.action_mailer.delivery_method = ENV['DISABLE_PROD_EMAIL'] ? :test : :smtp
   config.action_mailer.smtp_settings = {
     :authentication => :plain,
     :address => "smtp.mailgun.org",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "lockbox_rails_production"
 
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = ENV['DISABLE_PROD_EMAIL'] :test : :smtp
   config.action_mailer.smtp_settings = {
     :authentication => :plain,
     :address => "smtp.mailgun.org",


### PR DESCRIPTION
https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration

## Changelog
* Emails will not send if DISABLE_PROD_EMAIL is set

## Link to issue:  
#306 

