### PR TITLE
Explicitly set money gem behavior

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,3 +1,5 @@
 # This will use the money formatting specified by default in rails-i18n, e.g.:
 #   Money.new(10_000_00, 'USD').format # => $10,000.00
 Money.locale_backend = :i18n
+Money.default_currency = Money::Currency.new("USD")
+Money.rounding_mode = BigDecimal::ROUND_HALF_UP


### PR DESCRIPTION
## Changelog
- Set default currency for Money gem to USD
- Set default rounding behavior for Money gem to ROUND_HALF_UP

## Link to issue:  
Fixes #304 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
- N/A

## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added revelant screenshots
