### PR TITLE
Fix lockbox partner edit form

### DIFF
--- a/app/controllers/lockbox_partners_controller.rb
+++ b/app/controllers/lockbox_partners_controller.rb
@@ -22,7 +22,7 @@ class LockboxPartnersController < ApplicationController
 
   def update
     if @lockbox_partner.update(lockbox_params)
-      redirect_to @lockbox_partner, notice: 'Contact information was successfully updated.'
+      redirect_to edit_lockbox_partner_path(@lockbox_partner), notice: 'Contact information was successfully updated.'
     else
       render :edit
     end
@@ -36,7 +36,7 @@ class LockboxPartnersController < ApplicationController
 
   def lockbox_params
     params.require(:lockbox_partner)
-          .permit(:name, :phone_number, :street_address,
+          .permit(:name, :phone_number, :phone_ext, :street_address,
                   :city, :state, :zip_code)
   end
 

--- a/app/controllers/lockbox_partners_controller.rb
+++ b/app/controllers/lockbox_partners_controller.rb
@@ -22,7 +22,10 @@ class LockboxPartnersController < ApplicationController
 
   def update
     if @lockbox_partner.update(lockbox_params)
-      redirect_to edit_lockbox_partner_path(@lockbox_partner), notice: 'Contact information was successfully updated.'
+      redirect_to(
+        (current_user.admin? ? @lockbox_partner : edit_lockbox_partner_path(@lockbox_partner)),
+        notice: 'Contact information was successfully updated.'
+      )
     else
       render :edit
     end

--- a/app/views/lockbox_partners/_lockbox_partner_inputs.html.erb
+++ b/app/views/lockbox_partners/_lockbox_partner_inputs.html.erb
@@ -13,19 +13,21 @@
 <div class="form-group">
   <%= f.label :state %>
   <%= f.select :state,
-    options_for_select(us_states),
-    {},
-    class: 'form-control',
-    required: true
+    us_states,
+    {
+      selected: f.object.state,
+    },
+    {
+      class: 'form-control',
+      required: true
+    }
   %>
 </div>
 <div class="form-group">
   <%= f.label :zip_code %>
   <%= f.text_field :zip_code,
     class: 'form-control',
-    minlength: 5,
-    maxlength: 5,
-    pattern: "[0-9]{5}",
+    pattern: "[0-9]{5}(|-[0-9]{4})",
     required: true
   %>
 </div>

--- a/spec/controllers/lockbox_partners_controller_spec.rb
+++ b/spec/controllers/lockbox_partners_controller_spec.rb
@@ -175,8 +175,8 @@ describe LockboxPartnersController do
         expect(authorized_lockbox_partner.reload.name).to eq(@new_name)
       end
 
-      it "redirects to the partner" do
-        expect(response).to redirect_to(lockbox_partner_path(authorized_lockbox_partner))
+      it "redirects to the lockbox partner edit page" do
+        expect(response).to redirect_to(edit_lockbox_partner_path(user_lockbox_partner))
       end
     end
 


### PR DESCRIPTION
## Changelog
- Editing lockbox partner stays on lockbox partner edit page
- Zip code allows for 9 digit zip code format (12345-6789)
- Phone extension is permitted and persisted
- Lockbox partner state is properly selected on load of edit page

## Link to issue:  
#323 

## Relevant Screenshots: 
<img width="776" alt="Screen Shot 2020-02-02 at 2 06 37 PM" src="https://user-images.githubusercontent.com/4739591/73614495-38151100-45c5-11ea-8425-8b487ecbb944.png">

