### PR TITLE
Show urgency flag only if not nil or empty string

### DIFF
--- a/app/views/lockbox_partners/support_requests/_flag.html.erb
+++ b/app/views/lockbox_partners/support_requests/_flag.html.erb
@@ -1,4 +1,4 @@
-<% if @support_request.urgency_flag %>
+<% if @support_request.urgency_flag.present? %>
   <div class="alert alert-primary d-flex">
     <div class="p-2">
       <i class="fa fa-info-circle alert-primary-icon" aria-hidden="true"></i>


### PR DESCRIPTION
## Changelog
- Empty string urgency flags do not appear on support requests

## Link to issue:  
#332 
