### PR TITLE
Render partner header regardless of partner status

### DIFF
--- a/app/views/lockbox_partners/support_requests/new.html.erb
+++ b/app/views/lockbox_partners/support_requests/new.html.erb
@@ -1,19 +1,21 @@
-  <% if @lockbox_partner.nil? || @lockbox_partner.active? %>
-    <% if @lockbox_partner %>
-      <%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
-      <%= render partial: 'support_requests/form', locals: { path: @path, form_action: "New" } %>
-    <% else %>
-      <div id="dashboard-lockbox-partners">
-        <%= render partial: 'lockbox_partners/back_to_dashboard', locals: {:alignment => 'left'} %>
-        <br/>
-        <%= render partial: 'lockbox_partners/dashboard_header' %>
-        <div id="support-request-form">
-          <%= render partial: 'support_requests/form', locals: { path: @path, form_action: "New" } %>
-        </div>
-      </div>
-    <% end %>
+<% if @lockbox_partner %>
+  <%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
+<% end %>
+<% if @lockbox_partner.nil? || @lockbox_partner.active? %>
+  <% if @lockbox_partner %>
+    <%= render partial: 'support_requests/form', locals: { path: @path, form_action: "New" } %>
   <% else %>
-    <p class="text-center">
-      Lockbox partner not yet active. There must be an active user and a completed cash addition.
-    </p>
+    <div id="dashboard-lockbox-partners">
+      <%= render partial: 'lockbox_partners/back_to_dashboard', locals: {:alignment => 'left'} %>
+      <br/>
+      <%= render partial: 'lockbox_partners/dashboard_header' %>
+      <div id="support-request-form">
+        <%= render partial: 'support_requests/form', locals: { path: @path, form_action: "New" } %>
+      </div>
+    </div>
   <% end %>
+<% else %>
+  <p class="text-center">
+    Lockbox partner not yet active. There must be an active user and a completed cash addition.
+  </p>
+<% end %>

--- a/spec/system/support_request_creation_spec.rb
+++ b/spec/system/support_request_creation_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Support Request Creation", type: :system do
   let!(:lockbox_partner) { FactoryBot.create(:lockbox_partner, :active, name: 'Gorillas R Us') }
+  let!(:inactive_lockbox_partner) { FactoryBot.create(:lockbox_partner) }
   let!(:user)            { FactoryBot.create(:user) }
 
   before do
@@ -34,6 +35,8 @@ RSpec.describe "Support Request Creation", type: :system do
   it 'can file a support request from a lockbox dashboard' do
     visit "/lockbox_partners/#{lockbox_partner.id}/support_requests/new"
 
+    assert_selector "h2", text: lockbox_partner.name
+
     fill_in 'Pick-up Date', with: Date.current
     fill_in 'Client Alias',  with: 'McGee'
     fill_in 'Client Reference ID', with: 'b358250'
@@ -51,5 +54,13 @@ RSpec.describe "Support Request Creation", type: :system do
     sleep(1)
     find_button("Save Note").click
     assert_selector "td", text: "Here's some fine & fancy note text!"
+  end
+
+  it 'cannot file a support request from an inactive lockbox dashboard' do
+    visit "/lockbox_partners/#{inactive_lockbox_partner.id}/support_requests/new"
+
+    assert_selector "h2", text: inactive_lockbox_partner.name
+    assert_no_selector "h2", text: "New support request"
+    assert_selector "p", text: "Lockbox partner not yet active"
   end
 end


### PR DESCRIPTION
## Changelog
- Made lockbox partner header display on the partner-specific support request view regardless of whether the partner is active or not.


## Link to issue:  
Fixes #327 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
![Screenshot_20200202_173530](https://user-images.githubusercontent.com/8214544/73617293-c0ee7580-45e2-11ea-9c5f-859abb53f723.png)



## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
