### PR TITLE
Fix styling of reconciliation and password edit forms

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -8,7 +8,7 @@
     </p>
   <% end %>
 
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), class: 'form', html: { method: :put }) do |f| %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'form' }) do |f| %>
     <%= devise_error_messages! %>
     <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'form' }) do |f| %>
   <%= devise_error_messages! %>
 
   <div>
@@ -9,23 +9,23 @@
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
-  <div class="field form-group">
+  <div class="form-group">
     <%= f.label :current_password %>
-    <%= f.password_field :current_password, autocomplete: "off", required: true %>
+    <%= f.password_field :current_password, autocomplete: "off", class: 'form-control', required: true %>
   </div>
 
-  <div class="field form-group">
+  <div class="form-group">
     <%= f.label :password, "New Password" %>
     <% if @minimum_password_length %>
       <em><%= @minimum_password_length %> characters minimum</em>
       <br />
     <% end %>
-    <%= f.password_field :password, autocomplete: "off", required: true %>
+    <%= f.password_field :password, autocomplete: "off", class: 'form-control', required: true %>
   </div>
 
-  <div class="field form-group">
+  <div class="form-group">
     <%= f.label :password_confirmation, "Re-enter Password" %>
-    <%= f.password_field :password_confirmation, autocomplete: "off", required: true %>
+    <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', required: true %>
   </div>
 
   <div class="actions form-group">

--- a/app/views/lockbox_partners/reconciliation/new.html.erb
+++ b/app/views/lockbox_partners/reconciliation/new.html.erb
@@ -1,23 +1,21 @@
-<div class="container">
-  <%= form_for :reconciliation, class: "form", url: lockbox_partner_reconciliation_path do |f| %>
-    <h2>Reconcile budget</h2>
-    <p>Please count the cash in the lockbox and record the actual cash value.</p>
-    <% if current_user.admin? %>
-      <div class="form-group">
-        <%= f.label "Partner Clinic" %>
-        <%= f.select :lockbox_partner_id, options_for_select(lockbox_partner_select_options, @lockbox_partner.id), {}, class: 'form-control', required: true %>
-      </div>
-    <% end %>
+<%= form_for :reconciliation, url: lockbox_partner_reconciliation_path, html: { class: 'form' } do |f| %>
+  <h2>Reconcile budget</h2>
+  <p>Please count the cash in the lockbox and record the actual cash value.</p>
+  <% if current_user.admin? %>
     <div class="form-group">
-      <%= f.label "Physical cash in lockbox" %>
-      <%= f.text_field :amount,
-        type: "number",
-        step: "0.01",
-        class: "form-control",
-        required: true %>
+      <%= f.label "Partner Clinic" %>
+      <%= f.select :lockbox_partner_id, options_for_select(lockbox_partner_select_options, @lockbox_partner.id), {}, class: 'form-control', required: true %>
     </div>
-    <%= f.submit "Submit", class: "btn btn-primary" %>
   <% end %>
-</div>
+  <div class="form-group">
+    <%= f.label "Physical cash in lockbox" %>
+    <%= f.text_field :amount,
+      type: "number",
+      step: "0.01",
+      class: "form-control",
+      required: true %>
+  </div>
+  <%= f.submit "Submit", class: "btn btn-primary" %>
+<% end %>
 
 <%= javascript_pack_tag 'forms', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
## Changelog
- fix styling of reconciliation form
- fix styling of password edit form
- fix styling of registration edit form

## Link to issue:  
#328 

## Relevant Screenshots: 
<img width="1082" alt="Screen Shot 2020-02-09 at 5 12 38 PM" src="https://user-images.githubusercontent.com/4739591/74112100-7ed3af80-4b5f-11ea-8764-9958b4ecd3e8.png">
<img width="1077" alt="Screen Shot 2020-02-09 at 5 12 10 PM" src="https://user-images.githubusercontent.com/4739591/74112102-8004dc80-4b5f-11ea-8a83-228a0586c219.png">
<img width="1072" alt="Screen Shot 2020-02-09 at 5 11 52 PM" src="https://user-images.githubusercontent.com/4739591/74112103-81360980-4b5f-11ea-9333-bfd15d816600.png">

