### PR TITLE
allow form submission with blank transactions

### DIFF
--- a/app/views/lockbox_partners/support_requests/_lockbox_transaction_fields.html.erb
+++ b/app/views/lockbox_partners/support_requests/_lockbox_transaction_fields.html.erb
@@ -4,7 +4,7 @@
     <%= f.select :category,
       options_for_select(expense_category_select_options, selected: f.object.category),
       { include_blank: true },
-      { class: 'form-control', required: true } %>
+      { class: 'form-control', required: f.index == 0 } %>
   </div>
   <div class="field form-group col-3 distance-field" style="<%= "#{'display: none' unless f.object.category == 'gas'}" %>">
     <%= f.label :distance, "Mileage" %>
@@ -21,5 +21,5 @@
       class: 'form-control',
       readonly: f.object.category == 'gas' %>
   </div>
-  <%= link_to_remove_association "X", f %>
+  <%= link_to_remove_association "X", f, { style: "#{'visibility: hidden' if f.index == 0}" } %>
 </div>


### PR DESCRIPTION
## Changelog
- Allows for submission of new support request form when there are empty fields for transactions, as long as one transaction is filled out.

## Link to issue:  
Fixes issue #367 


## Are you ready for review?:

- [x] Linked PR to the issue
