### PR TITLE
Handle insufficient funds cases issue 149

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ brew services start redis
 - 1080: Mailcatcher
 
 ### Login
-**MAC (Admin)**
+**Fund Admin**
 Username: `cats@test.com`
 Password: `password1234`
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Ports in use:
 * 1080: Mailcatcher
 
 ### Login
-**Admin**
+**MAC (Admin)**
 Username: `cats@test.com`  
 Password: `password1234`
 

--- a/app/controllers/support_requests_controller.rb
+++ b/app/controllers/support_requests_controller.rb
@@ -29,10 +29,10 @@ class SupportRequestsController < ApplicationController
   private
 
   def add_insufficient_funds_alert
-    flash[:alert] = %Q(
-      The Pending Support Requests exceed your Lockbox balance. Please reconcile
-      your current Lockbox, and if the balance is still negative, please reach
-      out to your lockbox manager at #{ENV['LOCKBOX_EMAIL']}.
+    flash[:alert] = %(
+      The Pending Support Requests exceed your Lockbox balance. If more funds
+      are not already on the way, please reach out to your lockbox manager at
+      #{ENV['LOCKBOX_EMAIL']}.
     ).strip
   end
 

--- a/app/mailers/lockbox_partner_mailer.rb
+++ b/app/mailers/lockbox_partner_mailer.rb
@@ -1,8 +1,20 @@
 class LockboxPartnerMailer < ApplicationMailer
-  def low_balance_alert
-    return unless ENV['LOW_BALANCE_ALERT_EMAIL'].present?
+  def insufficient_funds_alert
+    email_address = ENV['LOCKBOX_EMAIL']
+    return unless email_address.present?
+    subject = %Q(
+      [INSUFFICIENT LOCKBOX FUNDS] #{params[:lockbox_partner].name} can't cover
+      pending support requests
+    ).strip
 
-    @lockbox_partner = params[:lockbox_partner]
-    mail(to: ENV['LOW_BALANCE_ALERT_EMAIL'], subject: "[LOW LOCKBOX BALANCE] #{@lockbox_partner.name} needs cash")
+    mail(to: email_address, subject: subject)
+  end
+
+  def low_balance_alert
+    email_address = ENV['LOW_BALANCE_ALERT_EMAIL']
+    return unless email_address.present?
+    subject = "[LOW LOCKBOX BALANCE] #{params[:lockbox_partner].name} needs cash"
+
+    mail(to: email_address, subject: subject)
   end
 end

--- a/app/mailers/lockbox_partner_mailer.rb
+++ b/app/mailers/lockbox_partner_mailer.rb
@@ -1,9 +1,10 @@
 class LockboxPartnerMailer < ApplicationMailer
   def insufficient_funds_alert
+    @lockbox_partner = params[:lockbox_partner]
     email_address = ENV['LOCKBOX_EMAIL']
     return unless email_address.present?
     subject = %Q(
-      [INSUFFICIENT LOCKBOX FUNDS] #{params[:lockbox_partner].name} can't cover
+      [INSUFFICIENT LOCKBOX FUNDS] #{@lockbox_partner.name} can't cover
       pending support requests
     ).strip
 
@@ -11,9 +12,10 @@ class LockboxPartnerMailer < ApplicationMailer
   end
 
   def low_balance_alert
+    @lockbox_partner = params[:lockbox_partner]
     email_address = ENV['LOW_BALANCE_ALERT_EMAIL']
     return unless email_address.present?
-    subject = "[LOW LOCKBOX BALANCE] #{params[:lockbox_partner].name} needs cash"
+    subject = "[LOW LOCKBOX BALANCE] #{@lockbox_partner.name} needs cash"
 
     mail(to: email_address, subject: subject)
   end

--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -15,6 +15,7 @@ class LockboxPartner < ApplicationRecord
   # to reconcile the lockbox. TODO make this configurable (issue #138)
   RECONCILIATION_INTERVAL = 30
   MINIMUM_ACCEPTABLE_BALANCE = Money.new(30000)
+  ZERO_BALANCE = Money.new(0)
 
   scope :active, -> { with_active_user.with_initial_cash }
   scope :with_active_user, -> { joins(:users).merge(User.confirmed) }
@@ -42,6 +43,10 @@ class LockboxPartner < ApplicationRecord
 
   def low_balance?
     balance < MINIMUM_ACCEPTABLE_BALANCE
+  end
+
+  def insufficient_funds?
+    balance < ZERO_BALANCE
   end
 
   def cash_addition_confirmation_pending?

--- a/app/views/lockbox_partner_mailer/insufficient_funds_alert.html.erb
+++ b/app/views/lockbox_partner_mailer/insufficient_funds_alert.html.erb
@@ -1,0 +1,10 @@
+<html>
+  <head></head>
+  <body>
+    <h1>Insufficient funds warning!</h1>
+    <p>
+      <%= lockbox_partner.name %> needs additional funds ASAP. Their current
+      Pending Support Requests are larger than their current available balance.
+    </p>
+  </body>
+</html>

--- a/app/views/lockbox_partner_mailer/insufficient_funds_alert.html.erb
+++ b/app/views/lockbox_partner_mailer/insufficient_funds_alert.html.erb
@@ -3,7 +3,7 @@
   <body>
     <h1>Insufficient funds warning!</h1>
     <p>
-      <%= params[:lockbox_partner].name %> needs additional funds ASAP. Their current
+      <%= @lockbox_partner.name %> needs additional funds ASAP. Their current
       Pending Support Requests are larger than their current available balance.
     </p>
   </body>

--- a/app/views/lockbox_partner_mailer/insufficient_funds_alert.html.erb
+++ b/app/views/lockbox_partner_mailer/insufficient_funds_alert.html.erb
@@ -3,7 +3,7 @@
   <body>
     <h1>Insufficient funds warning!</h1>
     <p>
-      <%= lockbox_partner.name %> needs additional funds ASAP. Their current
+      <%= params[:lockbox_partner].name %> needs additional funds ASAP. Their current
       Pending Support Requests are larger than their current available balance.
     </p>
   </body>

--- a/app/views/lockbox_partner_mailer/insufficient_funds_alert.text.erb
+++ b/app/views/lockbox_partner_mailer/insufficient_funds_alert.text.erb
@@ -1,4 +1,4 @@
 Insufficient funds warning!
 
-<%= params[:lockbox_partner].name %> needs additional funds ASAP. Their current
+<%= @lockbox_partner.name %> needs additional funds ASAP. Their current
 Pending Support Requests are larger than their current available balance.

--- a/app/views/lockbox_partner_mailer/insufficient_funds_alert.text.erb
+++ b/app/views/lockbox_partner_mailer/insufficient_funds_alert.text.erb
@@ -1,4 +1,4 @@
 Insufficient funds warning!
 
-<%= lockbox_partner.name %> needs additional funds ASAP. Their current Pending
-Support Requests are larger than their current available balance.
+<%= params[:lockbox_partner].name %> needs additional funds ASAP. Their current
+Pending Support Requests are larger than their current available balance.

--- a/app/views/lockbox_partner_mailer/insufficient_funds_alert.text.erb
+++ b/app/views/lockbox_partner_mailer/insufficient_funds_alert.text.erb
@@ -1,0 +1,4 @@
+Insufficient funds warning!
+
+<%= lockbox_partner.name %> needs additional funds ASAP. Their current Pending
+Support Requests are larger than their current available balance.

--- a/app/views/lockbox_partner_mailer/low_balance_alert.html.erb
+++ b/app/views/lockbox_partner_mailer/low_balance_alert.html.erb
@@ -11,4 +11,3 @@
     </div>
   </body>
 </html>
-

--- a/lib/create_support_request.rb
+++ b/lib/create_support_request.rb
@@ -73,14 +73,7 @@ class CreateSupportRequest
 
     support_request.record_creation
     send_low_balance_alert if support_request.lockbox_partner.low_balance?
-    if support_request.lockbox_partner.insufficient_funds?
-      flash[:alert] << %Q(
-        The Pending Support Requests exceed your Lockbox balance. Please reconcile
-        your current Lockbox, and if the balance is still negative, please reach
-        out to your lockbox manager at #{ENV[LOCKBOX_EMAIL]}.
-      ).strip
-      send_insufficient_funds_alert
-    end
+    send_insufficient_funds_alert if support_request.lockbox_partner.insufficient_funds?
 
     support_request
   rescue CreateSupportRequest::ValidationError => err

--- a/lib/create_support_request.rb
+++ b/lib/create_support_request.rb
@@ -73,13 +73,31 @@ class CreateSupportRequest
 
     support_request.record_creation
     send_low_balance_alert if support_request.lockbox_partner.low_balance?
+    if support_request.lockbox_partner.insufficient_funds?
+      flash[:alert] << %Q(
+        The Pending Support Requests exceed your Lockbox balance. Please reconcile
+        your current Lockbox, and if the balance is still negative, please reach
+        out to your lockbox manager at #{ENV[LOCKBOX_EMAIL]}.
+      ).strip
+      send_insufficient_funds_alert
+    end
 
     support_request
   rescue CreateSupportRequest::ValidationError => err
     fail!(err.message)
   end
 
+  def send_insufficient_funds_alert
+    LockboxPartnerMailer
+    .with(lockbox_partner: support_request.lockbox_partner)
+    .insufficient_funds_alert
+    .deliver
+  end
+
   def send_low_balance_alert
-    LockboxPartnerMailer.with(lockbox_partner: support_request.lockbox_partner).low_balance_alert.deliver
+    LockboxPartnerMailer
+      .with(lockbox_partner: support_request.lockbox_partner)
+      .low_balance_alert
+      .deliver
   end
 end

--- a/lib/create_support_request.rb
+++ b/lib/create_support_request.rb
@@ -72,8 +72,11 @@ class CreateSupportRequest
     end
 
     support_request.record_creation
-    send_low_balance_alert if support_request.lockbox_partner.low_balance?
-    send_insufficient_funds_alert if support_request.lockbox_partner.insufficient_funds?
+    if support_request.lockbox_partner.insufficient_funds?
+      send_insufficient_funds_alert
+    elsif support_request.lockbox_partner.low_balance?
+      send_low_balance_alert
+    end
 
     support_request
   rescue CreateSupportRequest::ValidationError => err

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -243,7 +243,7 @@ describe CreateSupportRequest do
       ).complete!
     end
 
-    it 'goes to the finance team when balance is below $0' do
+    it 'goes to the lockbox email address when balance is below $0' do
       allow(ENV).to receive(:[]).with('LOCKBOX_EMAIL').and_return('insufficientfunds@alert.com')
 
       result = nil
@@ -270,7 +270,7 @@ describe CreateSupportRequest do
       expect {
         CreateSupportRequest.call(params: insufficient_funds_params)
         NoteMailerWorker.drain
-      }.to change{ActionMailer::Base.deliveries.length}
+      }.to change { ActionMailer::Base.deliveries.length }
     end
 
     # What is this actually testing? The expecatation would be the same whether

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -199,12 +199,87 @@ describe CreateSupportRequest do
       }.to change{ActionMailer::Base.deliveries.length}
     end
 
-    it 'is not sent when the balance remains above $300' do
+    # What is this actually testing? The expecatation would be the same whether
+    # it's sent or not.
+    xit 'is not sent when the balance remains above $300' do
       allow(ENV).to receive(:[]).with('LOW_BALANCE_ALERT_EMAIL').and_return('lowbalance@alert.com')
 
       AddCashToLockbox.call!(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE + Money.new(15000)).complete!
 
       params[:lockbox_action_attributes][:lockbox_transactions_attributes]["0"][:amount] = 100
+      expect {
+        CreateSupportRequest.call(params: params)
+        NoteMailerWorker.drain
+      }.to change{ActionMailer::Base.deliveries.length}
+    end
+  end
+
+  describe "insufficient funds alert" do
+    let(:insufficient_funds_lockbox_partner) { FactoryBot.create(:lockbox_partner, :active) }
+    let(:insufficient_funds_params) do
+      {
+        client_ref_id:      "1234",
+        name_or_alias:      "some name",
+        urgency_flag:       "urgent",
+        lockbox_partner_id: insufficient_funds_lockbox_partner.id,
+        lockbox_action_attributes: {
+          eff_date:         Date.current,
+          lockbox_transactions_attributes: {
+            "0": {
+              amount:       Money.new(1100),
+              category:     "gas"
+            }
+          }
+        },
+        user_id:            mac_user.id,
+      }
+    end
+
+    before do
+      AddCashToLockbox.call!(
+        lockbox_partner: insufficient_funds_lockbox_partner,
+        eff_date: 1.day.ago,
+        amount: Money.new(1000)
+      ).complete!
+    end
+
+    it 'goes to the finance team when balance is below $0' do
+      allow(ENV).to receive(:[]).with('LOCKBOX_EMAIL').and_return('insufficientfunds@alert.com')
+
+      result = nil
+
+      expect { result = CreateSupportRequest.call(params: insufficient_funds_params) }
+        .to change{ActionMailer::Base.deliveries.length}
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail).to be_present
+      expect(mail.to).to include ENV['LOCKBOX_EMAIL']
+
+      expect(mail.parts.detect { |p| p.mime_type == "text/plain" }.body.raw_source)
+        .to include insufficient_funds_lockbox_partner.name
+      expect(mail.parts.detect{ |p| p.mime_type == "text/html" }.body.raw_source)
+        .to include insufficient_funds_lockbox_partner.name
+    end
+
+    # The deliveries count will still change by 1 because the creation alert was
+    # still sent
+
+    it "doesn't blow up when email is missing" do
+      allow(ENV).to receive(:[]).with('LOCKBOX_EMAIL').and_return(nil)
+
+      expect {
+        CreateSupportRequest.call(params: insufficient_funds_params)
+        NoteMailerWorker.drain
+      }.to change{ActionMailer::Base.deliveries.length}
+    end
+
+    # What is this actually testing? The expecatation would be the same whether
+    # it's sent or not.
+    xit 'is not sent when the balance remains above $0' do
+      allow(ENV).to receive(:[]).with('LOCKBOX_EMAIL').and_return('insufficientfunds@alert.com')
+
+      AddCashToLockbox.call!(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: Money.new(35000)).complete!
+
       expect {
         CreateSupportRequest.call(params: params)
         NoteMailerWorker.drain

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -171,12 +171,12 @@ describe CreateSupportRequest do
     end
 
     it 'goes to the finance team when balance is below $300' do
-      allow(ENV).to receive(:[]).with('LOW_BALANCE_ALERT_EMAIL').and_return('lowbalance@alert.com')
+      stub_const('ENV', ENV.to_hash.merge('LOW_BALANCE_ALERT_EMAIL' => 'lowbalance@alert.com'))
 
       result = nil
 
       expect { result = CreateSupportRequest.call(params: low_balance_params) }
-        .to change{ActionMailer::Base.deliveries.length}
+        .to change { ActionMailer::Base.deliveries.length }
       expected_dollar_value = (LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE - Money.new(100)).to_s
 
       mail = ActionMailer::Base.deliveries.last
@@ -191,12 +191,16 @@ describe CreateSupportRequest do
     # still sent
 
     it "doesn't blow up when email is missing" do
-      allow(ENV).to receive(:[]).with('LOW_BALANCE_ALERT_EMAIL').and_return(nil)
+      stub_const('ENV', ENV.to_hash.merge('LOW_BALANCE_ALERT_EMAIL' => 'lowbalance@alert.com'))
 
+      puts "BEFORE #{ActionMailer::Base.deliveries.length}"
       expect {
         CreateSupportRequest.call(params: low_balance_params)
         NoteMailerWorker.drain
-      }.to change{ActionMailer::Base.deliveries.length}
+      }.to change {
+        ActionMailer::Base.deliveries.length
+      }
+      puts "AFTER #{ActionMailer::Base.deliveries.length}"
     end
 
     # What is this actually testing? The expecatation would be the same whether

--- a/spec/mailers/lockbox_partner_mailer_spec.rb
+++ b/spec/mailers/lockbox_partner_mailer_spec.rb
@@ -36,7 +36,8 @@ describe LockboxPartnerMailer, type: :mailer do
     it "alerts the recipient to the low balance" do
       alert_text = "The lockbox balance at <b>#{lockbox_partner.name}</b> is at " \
                    "<b>$#{lockbox_partner.balance.to_s}</b>"
-      expect(email.body.encoded).to include(alert_text)
+      # `CGI.unescapeHTML` turns HTML entities back into chars (e.g. `&#39;` back into `'`)
+      expect(CGI.unescapeHTML(email.body.encoded)).to include(alert_text)
     end
   end
 end


### PR DESCRIPTION
## Changelog
* Add `#insufficient_funds?` helper method to `LockboxPartner`
* Add NSF send alert method; refactor low balance method for readability/consistency
* Add NSF mailer action; refactor low balance mailer action for readability/consistency
* Add NSF email body views

## Link to issue:
Fixes #149 

## Steps for QA/Special Notes:
1. Run `mailcatcher` in a separate terminal window. If you see something like 
    > mailcatcher: command not found

    Run `gem install mailcatcher`, then try again.

1. Open a browser tab to [localhost port 1080](http://127.0.0.1:1080).
1. Log in as MAC (admin) user
1. For any lockbox partner, create a new support request for more than is available
1. On submission, you should be redirected to the Lockbox partner's show page with an alert
1. In the mailcatcher browser tab, there should be a new Insufficient Funds email

## Relevant Screenshots: 
<img width="1264" alt="Screen Shot 2020-03-01 at 6 30 45 PM" src="https://user-images.githubusercontent.com/6441226/75637308-3bfb7980-5beb-11ea-96bf-7df5687e2819.png">
<img width="1279" alt="Screen Shot 2020-03-01 at 6 32 34 PM" src="https://user-images.githubusercontent.com/6441226/75637312-3dc53d00-5beb-11ea-863b-9660ef3cdb8b.png">

## Are you ready for review?:
Almost

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
