### PR TITLE
Improve mobile styling for support request view

### DIFF
--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -77,10 +77,16 @@ $note-form-color: #d6d7d9;
     .tab {
       display: inline-block;
       text-decoration: none;
-      padding: 17px;
-      width: 250px;
+      width: 100%;
+      padding-bottom: 17px;
       .btn {
         width: 100%;
+      }
+    }
+    @media screen and (min-width: 768px) {
+      .tab {
+        width: 250px;
+        padding: 17px;
       }
     }
     .tab.selected {
@@ -143,15 +149,23 @@ $note-form-color: #d6d7d9;
     div {
       p {
         font-size: 2em;
+        margin-bottom: 0;
       }
     }
+  }
+  .support-request-details > div {
+    margin-bottom: 13px;
   }
   .lockbox-activity {
     margin-top: -30px;
   }
   .status-label {
     font-size: 1.5em;
-    text-align: right;
+  }
+  @media screen and (min-width: 768px) {
+    .dropdown {
+      text-align: right;
+    }
   }
   .icon-spacer {
     margin-right: 1.25em;

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -18,6 +18,11 @@
       background-color: $darker-blue;
     }
   }
+  @media screen and (min-width: 768px) {
+    .dropdown {
+      text-align: right;
+    }
+  }
 }
 $note-form-color: #d6d7d9;
 

--- a/app/views/lockbox_partners/support_requests/_coordinator_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_coordinator_status_dropdown.html.erb
@@ -1,4 +1,4 @@
-<div class="dropdown float-right">
+<div class="dropdown">
   <% if label %>
     <p>Update Status</p>
   <% end %>

--- a/app/views/lockbox_partners/support_requests/_details_admin.html.erb
+++ b/app/views/lockbox_partners/support_requests/_details_admin.html.erb
@@ -1,25 +1,29 @@
 <div class="support-request-header">
   <% locals =  { support_request: @support_request, label: false } %>
-  <%= render partial: 'coordinator_status_dropdown', locals: locals %>
-  <h3>Support Request for <%= @support_request.name_or_alias %></h3>
+  <div class="row">
+    <h3 class="col-12 col-md-8">Support Request for <%= @support_request.name_or_alias %></h3>
+    <div class="col-12 col-md-4">
+      <%= render partial: 'coordinator_status_dropdown', locals: locals %>
+    </div>
+  </div>
   <%= render partial: 'flag', locals: { support_request: @support_request } %>
 </div>
-<div class="row">
-  <div class="col-3">
+<div class="row support-request-details">
+  <div class="col-12 col-md-3">
     <strong>Pickup Date</strong>
     <p><%= @support_request&.pickup_date %></p>
   </div>
-  <div class="col-3">
+  <div class="col-12 col-md-3">
     <strong>Amount</strong>
     <p>$<%= @support_request&.amount %></p>
   </div>
-  <div class="col-3">
+  <div class="col-12 col-md-3">
     <strong>Amount Breakdown</strong>
     <% @support_request.lockbox_action.breakdown.each do |item| %>
       <div><%= item[:amount] %> for <%= item[:category] %></div>
     <% end %>
   </div>
-  <div class="col-3">
+  <div class="col-12 col-md-3">
     <strong>Client ID</strong>
     <div><%= @support_request&.client_ref_id %></div>
   </div>

--- a/app/views/lockbox_partners/support_requests/_pending.html.erb
+++ b/app/views/lockbox_partners/support_requests/_pending.html.erb
@@ -1,9 +1,13 @@
 <div class="pending-request">
   <div class="header">
-    <div class="content">
-      <%= render partial: 'lockbox_partners/support_requests/status_dropdown', locals: { support_request: support_request, label: true } %>
-      <p><b><%= support_request.pickup_date.strftime('%B %d, %Y') %> - <%= support_request.name_or_alias %></b></p>
-      <h3>Support Request:  $<%= support_request.amount %></h3>
+    <div class="content row">
+      <div class="col-12 col-md-8">
+        <p><b><%= support_request.pickup_date.strftime('%B %d, %Y') %> - <%= support_request.name_or_alias %></b></p>
+        <h3>Support Request:  $<%= support_request.amount %></h3>
+      </div>
+      <div class="col-12 col-md-4">
+        <%= render partial: 'lockbox_partners/support_requests/status_dropdown', locals: { support_request: support_request, label: true } %>
+      </div>
     </div>
   </div>
   <div class="notes">

--- a/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
+++ b/app/views/lockbox_partners/support_requests/_status_dropdown.html.erb
@@ -1,4 +1,4 @@
-<div class="dropdown float-right">
+<div class="dropdown">
   <% if label %>
     <p>Update Status</p>
   <% end %>


### PR DESCRIPTION
## Changelog
- Smaller PR peeled from mobile improvements branch

## Link to issue:  
#280

## Steps for QA/Special Notes:
This does not represent a final product, simply: does the support request view look better than master?

## Relevant Screenshots: 
<img width="487" alt="Screen Shot 2020-03-08 at 3 46 51 PM" src="https://user-images.githubusercontent.com/4739591/76170889-4b7f4300-6154-11ea-9722-871a6bc0e7c9.png">

## Are you ready for review?:
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
