### PR TITLE
Issue #382 - Adding instruction text for Urgency Flag

### DIFF
--- a/app/views/support_requests/_form.html.erb
+++ b/app/views/support_requests/_form.html.erb
@@ -20,7 +20,7 @@
   <% end %>
   <div class="form-group">
     <%= f.label :name_or_alias, 'Client Alias' %>
-    <small class="form-text text-muted">Please do not use legal name</small>
+    <p class="form-text text-muted font-italic my-0">Please do not use legal name</p>
     <%= f.text_field :name_or_alias, class: 'form-control', required: true %>
   </div>
   <div class="form-group">
@@ -43,7 +43,8 @@
   <legend id="total">Total: $0.00</legend>
   <div class="form-group">
     <%= f.label :urgency_flag %>
-    <%= f.text_field :urgency_flag, class: 'form-control' %>
+    <p class="form-text text-muted font-italic my-0">Displays in email subject line (75 character limit)</p>
+    <%= f.text_field :urgency_flag, class: 'form-control', maxlength: "75" %>
   </div>
   <%= f.submit "Submit", class: 'btn btn-primary' %>
 <% end %>


### PR DESCRIPTION
## Changelog
- Added instruction text for Urgency Flag and updated styling for instruction texts on the Support Requests page (affects Client Alias - "Please do not use legal name")
- Set character limit on Urgency Flag input to "75" https://stackoverflow.com/questions/1592291/what-is-the-email-subject-length-limit

## Link to issue:  
Fixes issue #382 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
<img width="593" alt="Screen Shot 2020-03-08 at 4 38 41 PM" src="https://user-images.githubusercontent.com/34173394/76171765-f09e1980-615c-11ea-8d92-5200737537ab.png">



## Are you ready for review?:

- [ ] Added relevant tests
- [x] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [x] Added revelant screenshots
