### PR TITLE
Issue #378 - Adding instruction text to Client ID

### DIFF
--- a/app/views/support_requests/_form.html.erb
+++ b/app/views/support_requests/_form.html.erb
@@ -25,6 +25,7 @@
   </div>
   <div class="form-group">
     <%= f.label :client_ref_id, 'Client Reference ID' %>
+    <p class="form-text text-muted font-italic my-0">Use the Client ID from the Client Coordination Airtable here. If the client hasn't yet gone through intake, please type "Intake Pending"</p>
     <%= f.text_field :client_ref_id, class: 'form-control', required: true %>
   </div>
   <%= f.fields_for :lockbox_action, @support_request.lockbox_action || empty_lockbox_action do |la| %>


### PR DESCRIPTION
## Changelog
Added instruction text to Client ID in support request partial


## Link to issue:  
#378 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
(This includes #397)
<img width="470" alt="Screen Shot 2020-03-08 at 5 41 19 PM" src="https://user-images.githubusercontent.com/34173394/76172532-17604e00-6165-11ea-993c-bcb0a39729a1.png">

## Are you ready for review?:

- [ ] Added relevant tests
- [x] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [x] Added revelant screenshots
