### PR TITLE
only display extra horizontal rule if actually displaying an admin alert

### DIFF
--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -70,6 +70,10 @@ class LockboxPartner < ApplicationRecord
     true
   end
 
+  def has_admin_alerts?
+    recently_completed_first_cash_addition? || longstanding_pending_cash_addition?
+  end
+
   def relevant_transactions_for_balance(exclude_pending: false)
     excluded_statuses = [ LockboxAction::CANCELED ]
     excluded_statuses << LockboxAction::PENDING if exclude_pending

--- a/app/views/lockbox_partners/show.html.erb
+++ b/app/views/lockbox_partners/show.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'header', locals: { lockbox_partner: @lockbox_partner } %>
-<% if current_user.admin? %>
+<% if current_user.admin? && @lockbox_partner.has_admin_alerts? %>
   <%= render partial: 'lockbox_partners/admin_alerts', locals: { lockbox_partner: @lockbox_partner } %>
   <div class="horizontal-rule"></div>
 <% end %>


### PR DESCRIPTION
## Changelog
- Remove extra horizontal rule when it is unnecessary


## Link to issue:  
Fixes issue #396 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
<img width="801" alt="Screen Shot 2020-03-22 at 2 54 02 PM" src="https://user-images.githubusercontent.com/10442753/77259075-fb70a800-6c4c-11ea-829a-d6ef248e62eb.png">


## Are you ready for review?:

- [x] Linked PR to the issue
- [x] Added revelant screenshots
