### PR TITLE
Hotfix for icon loadings in prod CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -32,7 +32,7 @@ SecureHeaders::Configuration.default do |config|
     base_uri: %w('self'),
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
     child_src: %w('self'), # if child-src isn't supported, the value for frame-src will be set.
-    font_src: %w('self' data: https://fonts.gstatic.com),
+    font_src: %w('self' data: https://fonts.gstatic.com https://demo-lockbox.herokuapp.com),
     form_action: %w('self'),
     frame_ancestors: %w('none'),
     img_src: %w('self' https://*.amazonaws.com), # Whitelist amazonaws to support the Sqreen image


### PR DESCRIPTION
Note -- this is a short term solution. The root issue is why prod is trying to pull assets from staging 😬 

## Changelog
- Quick fix follow up to https://github.com/MidwestAccessCoalition/lockbox_rails/pull/321 to ensure that fontawesome icons load
![image](https://user-images.githubusercontent.com/5728859/78872137-68868a80-7a0e-11ea-8048-62fee41d915d.png)

## Link to issue:  
Follow up to https://github.com/MidwestAccessCoalition/lockbox_rails/pull/321


## Steps for QA/Special Notes:
Have already QA-ed manually by deploying

## Relevant Screenshots: 



## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added revelant screenshots
