### PR TITLE
Add hotel reinbursement category and humanize display of categories

### DIFF
--- a/app/helpers/support_requests_helper.rb
+++ b/app/helpers/support_requests_helper.rb
@@ -1,6 +1,6 @@
 module SupportRequestsHelper
   def expense_category_select_options
-    LockboxTransaction::EXPENSE_CATEGORIES.map { |c| [c.capitalize, c] }
+    LockboxTransaction::EXPENSE_CATEGORIES.map { |c| [c.humanize, c] }
   end
 
   def lockbox_partner_select_options

--- a/app/models/lockbox_transaction.rb
+++ b/app/models/lockbox_transaction.rb
@@ -16,14 +16,15 @@ class LockboxTransaction < ApplicationRecord
   validates :balance_effect, inclusion: BALANCE_EFFECTS
 
   EXPENSE_CATEGORIES = [
-    GAS           = 'gas',
-    PARKING       = 'parking',
-    TRANSIT       = 'transit',
-    CHILDCARE     = 'childcare',
-    MEDICINE      = 'medicine',
-    FOOD          = 'food',
-    ADJUSTMENT    = 'adjustment',
-    CASH_ADDITION = 'cash_addition'
+    GAS                 = 'gas',
+    PARKING             = 'parking',
+    TRANSIT             = 'transit',
+    CHILDCARE           = 'childcare',
+    MEDICINE            = 'medicine',
+    FOOD                = 'food',
+    ADJUSTMENT          = 'adjustment',
+    CASH_ADDITION       = 'cash_addition',
+    HOTEL_REINBURSEMENT = 'hotel_reinbursement'
   ].freeze
   validates :category, inclusion: EXPENSE_CATEGORIES
 

--- a/app/models/lockbox_transaction.rb
+++ b/app/models/lockbox_transaction.rb
@@ -24,7 +24,7 @@ class LockboxTransaction < ApplicationRecord
     FOOD                = 'food',
     ADJUSTMENT          = 'adjustment',
     CASH_ADDITION       = 'cash_addition',
-    HOTEL_REINBURSEMENT = 'hotel_reinbursement'
+    HOTEL_REIMBURSEMENT = 'hotel_reimbursement'
   ].freeze
   validates :category, inclusion: EXPENSE_CATEGORIES
 

--- a/app/views/lockbox_partners/support_requests/_details_admin.html.erb
+++ b/app/views/lockbox_partners/support_requests/_details_admin.html.erb
@@ -20,7 +20,9 @@
   <div class="col-12 col-md-3">
     <strong>Amount Breakdown</strong>
     <% @support_request.lockbox_action.breakdown.each do |item| %>
-      <div><%= item[:amount] %> for <%= item[:category] %></div>
+      <div>
+        <%= item[:amount] %> for <%= item[:category].humanize(capitalize: false) %>
+      </div>
     <% end %>
   </div>
   <div class="col-12 col-md-3">


### PR DESCRIPTION
## Changelog
- add hotel reinbursement to lockbox transaction expense categories
- humanize text of expense categories on form and show of lockbox transaction

## Link to issue:  
#412 

## Relevant Screenshots: 
<img width="610" alt="Screen Shot 2020-04-12 at 4 56 39 PM" src="https://user-images.githubusercontent.com/4739591/79080972-d1a42180-7cde-11ea-99f0-38e53f4dc010.png">

## Are you ready for review?:

- [x] Linked PR to the issue
- [x] Added revelant screenshots
