### PR TITLE
Adding link to google form

### DIFF
--- a/app/views/dashboard/support.html.erb
+++ b/app/views/dashboard/support.html.erb
@@ -3,11 +3,22 @@
   <p>
     If you're having issues in the app, please check out
     <% user_type = current_user.admin? ? "ADMIN" : "PARTNER" %>
-    <%= link_to "our FAQ manual", ENV["LOCKBOX_#{user_type}_FAQ_LINK"] %>
-    first.
-  </p>
-  <p>
-    If you can't find the answer there, you can also email
-    <%= link_to ENV["LOCKBOX_EMAIL"], "mailto:#{ENV["LOCKBOX_EMAIL"]}" %>.
-  </p>
-</div>
+      <%= link_to "our FAQ manual", ENV["LOCKBOX_#{user_type}_FAQ_LINK"] %>
+      first.
+    </p>
+    <p>
+      If you aren't able to find the answer there, you can also fill out this form and click submit to log your issue. Our all-volunteer IT team will start work on it right away, but the issue may remain for some time depending on how heavy their workload
+      is this week.
+    </p>
+
+    <p>
+      <a href="https://forms.gle/tw6MJQTgjfZhq2nD7" target="_blank">Fill out form</a> 
+    </p>
+
+    <p class="text-muted font-italic my-0">
+      If you need immediate assistance, please email
+    </p>
+    <p>
+      <%= link_to ENV["LOCKBOX_EMAIL"], "mailto:#{ENV["LOCKBOX_EMAIL"]}" %>.
+    </p>
+  </div>

--- a/app/views/dashboard/support.html.erb
+++ b/app/views/dashboard/support.html.erb
@@ -7,12 +7,14 @@
       first.
     </p>
     <p>
-      If you aren't able to find the answer there, you can also fill out this form and click submit to log your issue. Our all-volunteer IT team will start work on it right away, but the issue may remain for some time depending on how heavy their workload
+      If you aren't able to find the answer there, you can also
+      <%= link_to "fill out this form", ENV["ISSUE_FORM_LINK"] %>
+      and click submit to log your issue. Our all-volunteer IT team will start work on it right away, but the issue may remain for some time depending on how heavy their workload
       is this week.
     </p>
 
     <p>
-      <a href="https://forms.gle/tw6MJQTgjfZhq2nD7" target="_blank">Fill out form</a> 
+      <%= link_to "Log an Issue or Feedback", ENV["ISSUE_FORM_LINK"], :class => "btn btn-primary" %>
     </p>
 
     <p class="text-muted font-italic my-0">


### PR DESCRIPTION
## Changelog
Updated Get Support page to include Google Form link for ticket request


## Link to issue:  
#284 


## Steps for QA/Special Notes:
Originally we were going to embed the form but then wanted to mitigate security issues by using an existing form. We decided to go with Google Forms to give tech people access to the spreadsheets. Google forms cannot be embedded if they include file upload sections so we decided to make it just a link instead of an iframe.

## Relevant Screenshots: 
<img width="346" alt="Screen Shot 2020-05-10 at 2 32 48 PM" src="https://user-images.githubusercontent.com/34173394/81511044-56c52b00-92cb-11ea-8819-408553379c30.png">




## Are you ready for review?:

- [ ] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
