### PR TITLE
Adding tracking info to alert and email for "Add Cash"

### DIFF
--- a/app/models/lockbox_action.rb
+++ b/app/models/lockbox_action.rb
@@ -5,7 +5,7 @@ class LockboxAction < ApplicationRecord
   belongs_to :support_request, optional: true
   has_many :lockbox_transactions, dependent: :destroy
   has_many :notes, as: :notable
-  has_many :tracking_infos
+  has_one :tracking_info
 
   accepts_nested_attributes_for :lockbox_transactions, reject_if: :all_blank,
     allow_destroy: true
@@ -140,6 +140,12 @@ class LockboxAction < ApplicationRecord
 
   def debit?
     lockbox_transactions.first&.balance_effect == LockboxTransaction::DEBIT
+  end
+
+  def tracking_info_formatted
+    if tracking_info.present?
+      "#{tracking_info.delivery_method} #{tracking_info.tracking_number}"
+    end
   end
 
   private

--- a/app/views/lockbox_action_mailer/add_cash_email.text.erb
+++ b/app/views/lockbox_action_mailer/add_cash_email.text.erb
@@ -1,5 +1,4 @@
 MAC has sent cash for your lockbox in the amount of $<%= @lockbox_action.amount %>. Please log into the app to confirm once it's arrived.
 <% if @lockbox_action.tracking_info.present? %>
-  Tracking info:
-  <%=  @lockbox_action.tracking_info_formatted %>
+  Tracking info: <%= @lockbox_action.tracking_info_formatted %>
 <% end %>

--- a/app/views/lockbox_action_mailer/add_cash_email.text.erb
+++ b/app/views/lockbox_action_mailer/add_cash_email.text.erb
@@ -1,7 +1,5 @@
 MAC has sent cash for your lockbox in the amount of $<%= @lockbox_action.amount %>. Please log into the app to confirm once it's arrived.
-<% if @lockbox_action.tracking_infos.present? %>
+<% if @lockbox_action.tracking_info.present? %>
   Tracking info:
-  <% @lockbox_action.tracking_infos.each do |tracking_info| %>
-    <%= tracking_info.delivery_method %> <%= tracking_info.tracking_number %>
-  <% end %>
+  <%=  @lockbox_action.tracking_info_formatted %>
 <% end %>

--- a/app/views/lockbox_action_mailer/add_cash_email.text.erb
+++ b/app/views/lockbox_action_mailer/add_cash_email.text.erb
@@ -1,1 +1,7 @@
 MAC has sent cash for your lockbox in the amount of $<%= @lockbox_action.amount %>. Please log into the app to confirm once it's arrived.
+<% if @lockbox_action.tracking_infos.present? %>
+  Tracking info:
+  <% @lockbox_action.tracking_infos.each do |tracking_info| %>
+    <%= tracking_info.delivery_method %> <%= tracking_info.tracking_number %>
+  <% end %>
+<% end %>

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -24,8 +24,7 @@
         <div>A $<%= cash_action.amount %> check was mailed on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.</div>
 
         <% if cash_action.tracking_info.present? %>
-          <div>Tracking info:</div>
-          <div><%= cash_action.tracking_info_formatted %></div>
+          <div>Tracking info: <%= cash_action.tracking_info_formatted %></div>
         <% end %>
       </div>
       <div class="p-2">

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -23,11 +23,9 @@
         <h4 class="alert-heading">Cash Sent</h4>
         <div>A $<%= cash_action.amount %> check was mailed on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.</div>
 
-        <% if cash_action.tracking_infos.present? %>
+        <% if cash_action.tracking_info.present? %>
           <div>Tracking info:</div>
-          <% cash_action.tracking_infos.each do |tracking_info| %>
-            <div><%= tracking_info.delivery_method %> <%= tracking_info.tracking_number %></div>
-          <% end %>
+          <div><%= cash_action.tracking_info_formatted %></div>
         <% end %>
       </div>
       <div class="p-2">

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -22,6 +22,13 @@
       <div class="p-2 flex-grow-1">
         <h4 class="alert-heading">Cash Sent</h4>
         <div>A $<%= cash_action.amount %> check was mailed on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.</div>
+
+        <% if cash_action.tracking_infos.present? %>
+          <div>Tracking info:</div>
+          <% cash_action.tracking_infos.each do |tracking_info| %>
+            <div><%= tracking_info.delivery_method %> <%= tracking_info.tracking_number %></div>
+          <% end %>
+        <% end %>
       </div>
       <div class="p-2">
         <%= link_to "Confirm Cash Addition", lockbox_action_path(cash_action, {lockbox_action: {status: :completed}}), method: :put, class: 'btn btn-warning' %>

--- a/lib/add_cash_to_lockbox.rb
+++ b/lib/add_cash_to_lockbox.rb
@@ -21,7 +21,7 @@ class AddCashToLockbox
       end
 
       if tracking_number.present? || delivery_method.present?
-        lockbox_action.tracking_infos.create(
+        lockbox_action.tracking_info = TrackingInfo.create(
           tracking_number: tracking_number,
           delivery_method: delivery_method
         )

--- a/spec/lib/add_cash_to_lockbox_spec.rb
+++ b/spec/lib/add_cash_to_lockbox_spec.rb
@@ -69,6 +69,15 @@ describe AddCashToLockbox do
       expect(TrackingInfo.order(:created_at).last.tracking_number).to eq ("12345")
       expect(TrackingInfo.order(:created_at).last.delivery_method).to eq nil
     end
+
+
+    it "emails the tracking info" do
+      expect{ add_cash }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.subject).to eq('Incoming Lockbox Cash in the Mail')
+      expect(mail.body).to include(amount)
+      expect(mail.body).to include("12345")
+    end
   end
 
   context "when delivery method is passed in" do
@@ -83,6 +92,14 @@ describe AddCashToLockbox do
       expect{add_cash}.to change(TrackingInfo, :count).by(1)
       expect(TrackingInfo.order(:created_at).last.tracking_number).to eq nil
       expect(TrackingInfo.order(:created_at).last.delivery_method).to eq "Mail Today"
+    end
+
+    it "emails the tracking info" do
+      expect{ add_cash }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.subject).to eq('Incoming Lockbox Cash in the Mail')
+      expect(mail.body).to include(amount)
+      expect(mail.body).to include("Mail Today")
     end
   end
 
@@ -99,6 +116,15 @@ describe AddCashToLockbox do
       expect{add_cash}.to change(TrackingInfo, :count).by(1)
       expect(TrackingInfo.order(:created_at).last.tracking_number).to eq "123456"
       expect(TrackingInfo.order(:created_at).last.delivery_method).to eq "Mail Today"
+    end
+
+    it "emails the tracking info" do
+      expect{ add_cash }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.subject).to eq('Incoming Lockbox Cash in the Mail')
+      expect(mail.body).to include(amount)
+      expect(mail.body).to include("123456")
+      expect(mail.body).to include("Mail Today")
     end
   end
 

--- a/spec/models/lockbox_action_spec.rb
+++ b/spec/models/lockbox_action_spec.rb
@@ -5,10 +5,11 @@ describe LockboxAction, type: :model do
   it { is_expected.to belong_to(:support_request).optional }
   it { is_expected.to have_many(:lockbox_transactions) }
   it { is_expected.to have_many(:notes) }
+  it { is_expected.to have_one(:tracking_info) }
 
   describe '.create_with_transactions' do
     context 'some unknown status' do
-      it 'raises an error' do 
+      it 'raises an error' do
         action = LockboxAction.new(status: 'oops')
         action.valid?
         expect(action.errors.messages[:status]).to include('is not included in the list')
@@ -16,7 +17,7 @@ describe LockboxAction, type: :model do
     end
 
     context 'some unknown action type' do
-      it 'raises an error' do 
+      it 'raises an error' do
         action = LockboxAction.new(action_type: 'whoops')
         action.valid?
         expect(action.errors.messages[:action_type]).to include('is not included in the list')


### PR DESCRIPTION
## Changelog
- Adding "Tracking Info" to alert and email for "Add Cash" action


## Link to issue:  
#402 


## Steps for QA/Special Notes:
- There weren't any mocks provided in ticket. Please verify that it looks ok
- Checked in prod db and there aren't any conflicts/issues with existing data - there arent any lockbox actions that have multiple tracking infos

## Relevant Screenshots: 
(Email)
<img width="796" alt="Screen Shot 2020-05-17 at 3 30 36 PM" src="https://user-images.githubusercontent.com/34173394/82161664-7cb27880-9853-11ea-8f41-9e83f5ba804a.png">
(App alert)
<img width="1043" alt="Screen Shot 2020-05-17 at 3 28 50 PM" src="https://user-images.githubusercontent.com/34173394/82161665-7de3a580-9853-11ea-8b76-2219ce509a52.png">



## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
