### PR TITLE
Resolve csp issues 419

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,6 @@ gem 'sentry-raven'
 gem 'sidekiq'
 gem 'skylight'
 
-#gem 'secure_headers', '~> 6.3'
-
 group :production do
   gem 'sqreen', '>= 1.16'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'sentry-raven'
 gem 'sidekiq'
 gem 'skylight'
 
-gem 'secure_headers', '~> 6.3'
+#gem 'secure_headers', '~> 6.3'
 
 group :production do
   gem 'sqreen', '>= 1.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    secure_headers (6.3.0)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -401,7 +400,6 @@ DEPENDENCIES
   rspec-support!
   rspec_junit_formatter (~> 0.4.1)
   sass-rails (~> 5.1, >= 5.1.0)
-  secure_headers (~> 6.3)
   sentry-raven
   shoulda-matchers (~> 4.0, >= 4.0.1)
   sidekiq

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,17 +10,17 @@
 
 Rails.application.config.content_security_policy do |policy|
   policy.base_uri        :self
-  policy.default_src     :self, :https
-  policy.font_src        :self, :https, 'https://fonts.gstatic.com', 'https://demo-lockbox.herokuapp.com'
+  policy.default_src     :self
+  policy.font_src        :self, 'https://fonts.gstatic.com', 'https://demo-lockbox.herokuapp.com'
   policy.form_action     :self
   policy.frame_ancestors :none
-  policy.img_src         :self, :https, 'https://*.amazonaws.com'
+  policy.img_src         :self, 'https://*.amazonaws.com'
   policy.object_src      :none
-  policy.script_src      :self, :https
-  policy.style_src       :self, :https, :unsafe_inline, 'https://fonts.googleapis.com'
-  policy.worker_src      :self, :https
+  policy.script_src      :self
+  policy.style_src       :self, :unsafe_inline, 'https://fonts.googleapis.com'
+  policy.worker_src      :self
   # If you are using webpack-dev-server then specify webpack-dev-server host
-  policy.connect_src     :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+  policy.connect_src     :self, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
   policy.block_all_mixed_content true
   # Specify URI for violation reports

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,7 +14,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src        :self, 'https://fonts.gstatic.com', 'https://demo-lockbox.herokuapp.com'
   policy.form_action     :self
   policy.frame_ancestors :none
-  policy.img_src         :self, 'https://*.amazonaws.com'
+  policy.img_src         :self, 'https://*.amazonaws.com' # Whitelist amazonaws to support the Sqreen image
   policy.object_src      :none
   policy.script_src      :self
   policy.style_src       :self, :unsafe_inline, 'https://fonts.googleapis.com'

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,46 +6,46 @@
 # default config documentation is here:
 # https://www.rubydoc.info/gems/secure_headers/6.3.0#Default_values
 
-SecureHeaders::Configuration.default do |config|
-  config.cookies = {
-    secure: true, # mark all cookies as "Secure"
-    httponly: true, # mark all cookies as "HttpOnly"
-    samesite: {
-      lax: true # mark all cookies as SameSite=lax
-    }
-  }  # Add "; preload" and submit the site to hstspreload.org for best protection.
-
-  config.hsts = "max-age=#{1.week.to_i}"
-  config.x_frame_options = "DENY"
-  config.x_content_type_options = "nosniff"
-  config.x_xss_protection = "1; mode=block"
-  config.x_download_options = "noopen"
-  config.x_permitted_cross_domain_policies = "none"
-  config.referrer_policy = %w(origin-when-cross-origin strict-origin-when-cross-origin)
-  config.csp = {
-    # "meta" values. these will shape the header, but the values are not included in the header.
-    preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
-    disable_nonce_backwards_compatibility: true, # default: false. If false, `unsafe-inline` will be added automatically when using nonces. If true, it won't. See #403 for why you'd want this.
-
-    # directive values: these values will directly translate into source directives
-    default_src: %w('self'),
-    base_uri: %w('self'),
-    block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
-    child_src: %w('self'), # if child-src isn't supported, the value for frame-src will be set.
-    font_src: %w('self' data: https://fonts.gstatic.com https://demo-lockbox.herokuapp.com),
-    form_action: %w('self'),
-    frame_ancestors: %w('none'),
-    img_src: %w('self' https://*.amazonaws.com), # Whitelist amazonaws to support the Sqreen image
-    manifest_src: %w('self'),
-    media_src: %w('self'),
-    object_src: %w('self'),
-    sandbox: false, # true and [] will set a maximally restrictive setting
-    script_src: %w('self' 'unsafe-inline'), # unsafe-inline is needed for rails-ujs
-    style_src: %w('self' 'unsafe-inline' https://fonts.googleapis.com),
-    worker_src: %w('self'),
-    upgrade_insecure_requests: Rails.env.production?, # see https://www.w3.org/TR/upgrade-insecure-requests/
-  }  # This is available only from 3.5.0; use the `report_only: true` setting for 3.4.1 and below.
-end
+# SecureHeaders::Configuration.default do |config|
+#   config.cookies = {
+#     secure: true, # mark all cookies as "Secure"
+#     httponly: true, # mark all cookies as "HttpOnly"
+#     samesite: {
+#       lax: true # mark all cookies as SameSite=lax
+#     }
+#   }  # Add "; preload" and submit the site to hstspreload.org for best protection.
+#
+#   config.hsts = "max-age=#{1.week.to_i}"
+#   config.x_frame_options = "DENY"
+#   config.x_content_type_options = "nosniff"
+#   config.x_xss_protection = "1; mode=block"
+#   config.x_download_options = "noopen"
+#   config.x_permitted_cross_domain_policies = "none"
+#   config.referrer_policy = %w(origin-when-cross-origin strict-origin-when-cross-origin)
+#   config.csp = {
+#     # "meta" values. these will shape the header, but the values are not included in the header.
+#     preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
+#     disable_nonce_backwards_compatibility: true, # default: false. If false, `unsafe-inline` will be added automatically when using nonces. If true, it won't. See #403 for why you'd want this.
+#
+#     # directive values: these values will directly translate into source directives
+#     default_src: %w('self'),
+#     base_uri: %w('self'),
+#     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
+#     child_src: %w('self'), # if child-src isn't supported, the value for frame-src will be set.
+#     font_src: %w('self' data: https://fonts.gstatic.com https://demo-lockbox.herokuapp.com),
+#     form_action: %w('self'),
+#     frame_ancestors: %w('none'),
+#     img_src: %w('self' https://*.amazonaws.com), # Whitelist amazonaws to support the Sqreen image
+#     manifest_src: %w('self'),
+#     media_src: %w('self'),
+#     object_src: %w('self'),
+#     sandbox: false, # true and [] will set a maximally restrictive setting
+#     script_src: %w('self' 'unsafe-inline'), # unsafe-inline is needed for rails-ujs
+#     style_src: %w('self' 'unsafe-inline' https://fonts.googleapis.com),
+#     worker_src: %w('self'),
+#     upgrade_insecure_requests: Rails.env.production?, # see https://www.w3.org/TR/upgrade-insecure-requests/
+#   }  # This is available only from 3.5.0; use the `report_only: true` setting for 3.4.1 and below.
+# end
 # Below is the Rails auto-generated CSP config in case
 # we want to go back to this from SecureHeaders
 
@@ -53,27 +53,27 @@ end
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https, :unsafe_inline
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data, 'https://fonts.gstatic.com', 'https://demo-lockbox.herokuapp.com'
+  policy.img_src     :self, :https, :data, 'https://*.amazonaws.com'
+  policy.object_src  :none # Should self be enabled?
+  policy.script_src  :self, :https
+  policy.style_src   :self, :unsafe_inline, 'https://fonts.googleapis.com'
+  # If you are using webpack-dev-server then specify webpack-dev-server host
+  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
-# # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+# If you are using UJS then enable automatic nonce generation
+Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
 
-# # Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src style-src)
+# Set the nonce only to specific directives
+Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
 
-# # Report CSP violations to a specified URI
-# # For further information see the following documentation:
-# # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = false
+# Report CSP violations to a specified URI
+# For further information see the following documentation:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+Rails.application.config.content_security_policy_report_only = false

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,68 +1,28 @@
-# Be sure to restart your server when you modify this file.
-
-# We're using the secure_headers gem to handle our CSP
-# https://rubygems.org/gems/secure_headers/versions/6.3.0
-# SecureHeaders::Configuration.default
-# default config documentation is here:
-# https://www.rubydoc.info/gems/secure_headers/6.3.0#Default_values
-
-# SecureHeaders::Configuration.default do |config|
-#   config.cookies = {
-#     secure: true, # mark all cookies as "Secure"
-#     httponly: true, # mark all cookies as "HttpOnly"
-#     samesite: {
-#       lax: true # mark all cookies as SameSite=lax
-#     }
-#   }  # Add "; preload" and submit the site to hstspreload.org for best protection.
-#
-#   config.hsts = "max-age=#{1.week.to_i}"
-#   config.x_frame_options = "DENY"
-#   config.x_content_type_options = "nosniff"
-#   config.x_xss_protection = "1; mode=block"
-#   config.x_download_options = "noopen"
-#   config.x_permitted_cross_domain_policies = "none"
-#   config.referrer_policy = %w(origin-when-cross-origin strict-origin-when-cross-origin)
-#   config.csp = {
-#     # "meta" values. these will shape the header, but the values are not included in the header.
-#     preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
-#     disable_nonce_backwards_compatibility: true, # default: false. If false, `unsafe-inline` will be added automatically when using nonces. If true, it won't. See #403 for why you'd want this.
-#
-#     # directive values: these values will directly translate into source directives
-#     default_src: %w('self'),
-#     base_uri: %w('self'),
-#     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
-#     child_src: %w('self'), # if child-src isn't supported, the value for frame-src will be set.
-#     font_src: %w('self' data: https://fonts.gstatic.com https://demo-lockbox.herokuapp.com),
-#     form_action: %w('self'),
-#     frame_ancestors: %w('none'),
-#     img_src: %w('self' https://*.amazonaws.com), # Whitelist amazonaws to support the Sqreen image
-#     manifest_src: %w('self'),
-#     media_src: %w('self'),
-#     object_src: %w('self'),
-#     sandbox: false, # true and [] will set a maximally restrictive setting
-#     script_src: %w('self' 'unsafe-inline'), # unsafe-inline is needed for rails-ujs
-#     style_src: %w('self' 'unsafe-inline' https://fonts.googleapis.com),
-#     worker_src: %w('self'),
-#     upgrade_insecure_requests: Rails.env.production?, # see https://www.w3.org/TR/upgrade-insecure-requests/
-#   }  # This is available only from 3.5.0; use the `report_only: true` setting for 3.4.1 and below.
-# end
-# Below is the Rails auto-generated CSP config in case
-# we want to go back to this from SecureHeaders
-
 # Define an application-wide content security policy
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self, :https
-  policy.font_src    :self, :https, :data, 'https://fonts.gstatic.com', 'https://demo-lockbox.herokuapp.com'
-  policy.img_src     :self, :https, :data, 'https://*.amazonaws.com'
-  policy.object_src  :none # Should self be enabled?
-  policy.script_src  :self, :https
-  policy.style_src   :self, :unsafe_inline, 'https://fonts.googleapis.com'
-  # If you are using webpack-dev-server then specify webpack-dev-server host
-  policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+# Headers that are not set below:
+# * upgrade-insecure-requests, because it is not useful if block_all_mixed_content
+#   is set (see https://developers.google.com/web/fundamentals/security/prevent-mixed-content/fixing-mixed-content)
+# * media_src and manifest_src, because they will default to default_src, and
+#   the intended values are`the same
 
+Rails.application.config.content_security_policy do |policy|
+  policy.base_uri        :self
+  policy.default_src     :self, :https
+  policy.font_src        :self, :https, 'https://fonts.gstatic.com', 'https://demo-lockbox.herokuapp.com'
+  policy.form_action     :self
+  policy.frame_ancestors :none
+  policy.img_src         :self, :https, 'https://*.amazonaws.com'
+  policy.object_src      :none
+  policy.script_src      :self, :https
+  policy.style_src       :self, :https, :unsafe_inline, 'https://fonts.googleapis.com'
+  policy.worker_src      :self, :https
+  # If you are using webpack-dev-server then specify webpack-dev-server host
+  policy.connect_src     :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+
+  policy.block_all_mixed_content true
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"
 end


### PR DESCRIPTION
## Changelog
- Remove secure-headers gem and return to built-in Rails CSP tools
- Replace `upgrade-insecure-requests` with `block-all-mixed-content`
- Make a few other directives more restrictive to remove potentially insecure sources we're not usign

## Link to issue:  
Resolves #419 


## Steps for QA/Special Notes:
- The best way to QA this is to test all the functionality with the console open, so you'll see if any resources are being improperly blocked (and errors logged). I did this with every page and form I could think of, and found nothing.

## Relevant Screenshots: 
- N/A

## Are you ready for review?:

- [ ] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
