### PR TITLE
Downgrade snyk to fix build

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.16.0
+version: v1.14.1
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:
@@ -131,5 +131,3 @@ patch:
         patched: '2020-04-30T23:50:18.650Z'
     - '@rails/webpacker > @babel/preset-env > @babel/plugin-transform-exponentiation-operator > @babel/helper-builder-binary-assignment-operator-visitor > @babel/helper-explode-assignable-expression > @babel/traverse > @babel/helper-function-name > @babel/helper-get-function-arity > @babel/types > lodash':
         patched: '2020-04-30T23:50:18.650Z'
-    - graphlib > lodash:
-        patched: '2020-07-06T14:22:03.347Z'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "imports-loader": "^0.8.0",
     "jquery": "^3.5.1",
     "popper.js": "^1.15.0",
-    "snyk": "^1.360.0",
+    "snyk": "^1.316.1",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",


### PR DESCRIPTION
Heroku is using yarn 1.16.0 and node 10.15.3. These snyk changes from yesterday don't allow yarn to complete either on my local machine when using those versions or during the build process on ci. We may be able to find another way to patch this, in the mean time I suggest that we just revert this change. We are going to need to start running yarn locally before merging to master, better would be to get ci to use the same yarn and node versions as heroku during testing so that builds will fail