### PR TITLE
Improve low balance and insufficient funds alerts

### DIFF
--- a/app/mailers/lockbox_partner_mailer.rb
+++ b/app/mailers/lockbox_partner_mailer.rb
@@ -3,20 +3,22 @@ class LockboxPartnerMailer < ApplicationMailer
     @lockbox_partner = params[:lockbox_partner]
     email_address = ENV['LOCKBOX_EMAIL']
     return unless email_address.present?
+    admin_emails = User.get_admin_emails
     subject = %Q(
       [INSUFFICIENT LOCKBOX FUNDS] #{@lockbox_partner.name} can't cover
       pending support requests
     ).strip
 
-    mail(to: email_address, subject: subject)
+    mail(to: email_address, cc: admin_emails, subject: subject)
   end
 
   def low_balance_alert
     @lockbox_partner = params[:lockbox_partner]
     email_address = ENV['LOW_BALANCE_ALERT_EMAIL']
     return unless email_address.present?
+    admin_emails = User.get_admin_emails
     subject = "[LOW LOCKBOX BALANCE] #{@lockbox_partner.name} needs cash"
 
-    mail(to: email_address, subject: subject)
+    mail(to: email_address, cc: admin_emails, subject: subject)
   end
 end

--- a/app/mailers/lockbox_partner_mailer.rb
+++ b/app/mailers/lockbox_partner_mailer.rb
@@ -14,7 +14,7 @@ class LockboxPartnerMailer < ApplicationMailer
 
   def low_balance_alert
     @lockbox_partner = params[:lockbox_partner]
-    email_address = ENV['LOW_BALANCE_ALERT_EMAIL']
+    email_address = [ENV['LOW_BALANCE_ALERT_EMAIL'], ENV['LOCKBOX_EMAIL']].join(",")
     return unless email_address.present?
     admin_emails = User.get_admin_emails
     subject = "[LOW LOCKBOX BALANCE] #{@lockbox_partner.name} needs cash"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,10 @@ class User < ApplicationRecord
     self.name || "User #{id}"
   end
 
+  def self.get_admin_emails
+    User.admin.pluck(:email).join(",")
+  end
+
   private
 
   def password_required?

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -199,7 +199,7 @@ describe CreateSupportRequest do
       expect {
         CreateSupportRequest.call(params: low_balance_params)
         drain_queues
-      }.to change{ActionMailer::Base.deliveries.length}.by(2)
+      }.to change{ActionMailer::Base.deliveries.length}.by(3)
     end
 
     it 'is not sent when the balance remains above $300' do

--- a/spec/mailers/lockbox_partner_mailer_spec.rb
+++ b/spec/mailers/lockbox_partner_mailer_spec.rb
@@ -13,6 +13,8 @@ describe LockboxPartnerMailer, type: :mailer do
         .deliver_now
     end
 
+    let(:admin) { FactoryBot.create(:user) }
+
     before do
       allow(ENV)
         .to receive(:[])
@@ -28,7 +30,8 @@ describe LockboxPartnerMailer, type: :mailer do
     end
 
     it "ccs the admins" do
-      expect(email.cc).to eq([User.get_admin_emails])
+      expect(admin.email).to eq(User.get_admin_emails)
+      expect(email.cc).to eq([admin.email])
     end
 
     it "has the expected subject line" do

--- a/spec/mailers/lockbox_partner_mailer_spec.rb
+++ b/spec/mailers/lockbox_partner_mailer_spec.rb
@@ -5,6 +5,7 @@ describe LockboxPartnerMailer, type: :mailer do
 
   describe "#low_balance_alert" do
     let(:low_balance_alert_email) { "lowbalancealert@example.com" }
+    let(:lockbox_email) { "lockboxemail@example.com" }
 
     let(:email) do
       described_class
@@ -23,10 +24,14 @@ describe LockboxPartnerMailer, type: :mailer do
         .to receive(:[])
         .with("LOW_BALANCE_ALERT_EMAIL")
         .and_return(low_balance_alert_email)
+      allow(ENV)
+        .to receive(:[])
+        .with("LOCKBOX_EMAIL")
+        .and_return(lockbox_email)
     end
 
-    it "sends the email to the address specified in an env var" do
-      expect(email.to).to eq([low_balance_alert_email])
+    it "sends the email to the address specified in the env vars" do
+      expect(email.to).to eq([low_balance_alert_email, lockbox_email])
     end
 
     it "ccs the admins" do

--- a/spec/mailers/lockbox_partner_mailer_spec.rb
+++ b/spec/mailers/lockbox_partner_mailer_spec.rb
@@ -27,6 +27,10 @@ describe LockboxPartnerMailer, type: :mailer do
       expect(email.to).to eq([low_balance_alert_email])
     end
 
+    it "ccs the admins" do
+      expect(email.cc).to eq([User.get_admin_emails])
+    end
+
     it "has the expected subject line" do
       expect(email.subject).to eq(
         "[LOW LOCKBOX BALANCE] #{lockbox_partner.name} needs cash"


### PR DESCRIPTION
## Changelog
- When a partner's trigger amount is hit, emails should be sent to ENV['LOCKBOX_EMAIL'], ENV['LOW_BALANCE_ALERT_EMAIL'], and cc all users with "admin" role


## Link to issue:  
Fixes first part of issue #451 


## Steps for QA/Special Notes:
- For low balance and insufficient funds

## Relevant Screenshots: 
(CC'd to admins)
<img width="225" alt="Screen Shot 2020-07-16 at 9 41 01 PM" src="https://user-images.githubusercontent.com/34173394/87749321-3fb02700-c7ad-11ea-9af2-dfc6b945cb12.png">



## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
