### PR TITLE
Adding alerts for low balance

### DIFF
--- a/app/views/lockbox_partners/_admin_alerts.html.erb
+++ b/app/views/lockbox_partners/_admin_alerts.html.erb
@@ -8,6 +8,16 @@
     </div>
   </div>
 <% end %>
+<% if lockbox_partner.low_balance? %>
+  <div class="alert alert-danger d-flex">
+    <div class="p-2">
+      <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
+    </div>
+    <div class="p-2 flex-grow-1">
+      <div><%= lockbox_partner.name %>'s balance of $<%= lockbox_partner.balance %> is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. Please replenish the funds.</div>
+    </div>
+  </div>
+<% end %>
 <% if lockbox_partner.recently_completed_first_cash_addition? %>
   <div class="alert alert-success d-flex">
     <div class="p-2">

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -33,3 +33,17 @@
     </div>
   <% end %>
 <% end %>
+
+<% if lockbox_partner.low_balance? %>
+  <% alert_email = ENV['LOCKBOX_EMAIL'] %>
+  <div class="alert alert-danger d-flex">
+    <div class="p-2">
+      <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
+    </div>
+    <div class="p-2 flex-grow-1">
+      <div>
+        Your lockbox balance is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email <%= link_to alert_email, "mailto:#{alert_email}" %>.
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -40,17 +40,22 @@ describe CreateSupportRequest do
 
   subject { CreateSupportRequest.call(params: params) }
 
-  it "creates one note and triggers two emails" do
+  it 'creates one note and triggers two emails' do
+    get_request_emails = lambda do
+      ActionMailer::Base.deliveries.reject do |delivery|
+        delivery.subject['MAC Cash Box Withdrawal Request'].nil?
+      end
+    end
     notes_count = Note.count
-    emails_count = ActionMailer::Base.deliveries.count
+    emails_count = get_request_emails.call.count
 
     result = nil
 
     expect {
       result = subject
       drain_queues
-    }.to change{
-      [Note.count, ActionMailer::Base.deliveries.count]
+    }.to change {
+      [Note.count, get_request_emails.call.count]
     }.from([notes_count, emails_count]).to([notes_count+1, emails_count+2])
 
     expect(result).to be_success
@@ -249,7 +254,7 @@ describe CreateSupportRequest do
 
       result = nil
 
-      expect { 
+      expect {
         result = CreateSupportRequest.call(params: insufficient_funds_params)
         drain_queues
       }.to change{ ActionMailer::Base.deliveries.length }.by(3)

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+require './lib/create_support_request'
+
+RSpec.describe "Dashboard", type: :system do
+  ENV["LOCKBOX_EMAIL"] = "lockbox@email.com"
+
+  let!(:admin_user) { FactoryBot.create(:user) }
+  let!(:lockbox_partner) do
+    FactoryBot.create(:lockbox_partner, :with_active_user)
+  end
+
+  let(:submit_cash_addition) do
+    click_link("View Lockbox Partner Details")
+    click_link("Add cash to lockbox")
+    page.all(:fillable_field, 'add_cash_amount').last.set 500
+    click_button "Submit"
+
+    click_link "Back to dashboard"
+  end
+
+  describe "when user is an admin" do
+    before do
+      login_as(admin_user)
+      visit("/")
+    end
+
+    context "when a partner has low balance" do
+      # Expect 0 balance since there are no transactions
+      it "alerts for low balance without cash addition" do
+        page.assert_text("#{lockbox_partner.name}'s balance of $#{lockbox_partner.balance} is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. Please replenish the funds.")
+      end
+
+      it "alerts for low balance with unconfirmed cash addition" do
+        submit_cash_addition
+
+        page.assert_text("#{lockbox_partner.name}'s balance of $#{lockbox_partner.balance} is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. Please replenish the funds.")
+      end
+
+      it "doesn't alert for low balance with confirmed cash addition" do
+        submit_cash_addition
+
+        lockbox_partner.lockbox_actions.last.complete!
+
+        page.assert_no_text("#{lockbox_partner.name}'s balance of $#{lockbox_partner.balance} is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. Please replenish the funds.")
+      end
+    end
+
+  end
+
+  describe "when user is a partner" do
+    before do
+      login_as(lockbox_partner.users.last)
+      visit("/")
+    end
+
+    context "when a partner has low balance" do
+      # Expect 0 balance since there are no transactions
+      it "alerts for low balance without cash addition" do
+        page.assert_text("Your lockbox balance is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email #{ENV['LOCKBOX_EMAIL']}.")
+      end
+
+      it "removes alert for low balance with confirmed cash addition" do
+        lockbox_action = lockbox_partner.lockbox_actions.create!(
+          eff_date: Time.zone.now,
+          action_type: :add_cash,
+          status: LockboxAction::PENDING
+        )
+        lockbox_action.lockbox_transactions.create!(
+          amount_cents: 50000,
+          balance_effect: LockboxTransaction::CREDIT,
+          category: 'cash_addition'
+        )
+        visit("/")
+        page.assert_text("Your lockbox balance is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email #{ENV['LOCKBOX_EMAIL']}.")
+
+        click_link "Confirm Cash Addition"
+
+        page.assert_no_text("Your lockbox balance is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email #{ENV['LOCKBOX_EMAIL']}.")
+      end
+    end
+
+  end
+end


### PR DESCRIPTION

## Changelog
- Added persistent alerts for low balance for admin and partner


## Link to issue:  
Fixes part of issue #451 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
(partner dashboard)
![VideoToGif_GIF](https://user-images.githubusercontent.com/34173394/87845467-92a4df80-c87c-11ea-9e94-66a79e49177d.GIF)
---
(admin dashboard)
<img width="601" alt="Screen Shot 2020-07-17 at 10 28 08 PM" src="https://user-images.githubusercontent.com/34173394/87845506-e31c3d00-c87c-11ea-9096-461fc298c02e.png">


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added revelant screenshots
