### PR TITLE
Fixing typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Setup DB:
 bundle exec rake db:setup # runs `rake db:create db:schema:load db:seed
 ```
 
-_If you have issues at this step, see this [PostrgreSQL Setup](https://github.com/MidwestAccessCoalition/jane_point_oh/blob/master/docs/db_setup.md) doc. But while going through it, wherever you see the string `admin_app`, replace it with `lockbox_rails`. (This includes instances like `admin_app_development` => `lockbox_rails_development`.)_
+_If you have issues at this step, see this [PostgreSQL Setup](https://github.com/MidwestAccessCoalition/jane_point_oh/blob/master/docs/db_setup.md) doc. But while going through it, wherever you see the string `admin_app`, replace it with `lockbox_rails`. (This includes instances like `admin_app_development` => `lockbox_rails_development`.)_
 
 #### Mailcatcher
 


### PR DESCRIPTION
## Changelog
- Changed "PostrgreSQL" to "PostgreSQL" in readme (without the extra `r`)


## Link to issue:  
N/A

## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
<img width="307" alt="Screen Shot 2020-08-02 at 3 11 40 PM" src="https://user-images.githubusercontent.com/34173394/89133682-b9951f80-d4d2-11ea-8de5-c6282976180c.png">

