### PR TITLE
Disable active storage

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -5,7 +5,7 @@
 
 require('@rails/ujs').start();
 require('turbolinks').start();
-require('@rails/activestorage').start();
+//require('@rails/activestorage').start();
 require('babel-polyfill');
 require('channels');
 require('cocoon-js');

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
 
   # Store uploaded files on the local file system in a temporary directory.
-  config.active_storage.service = :test
+  # config.active_storage.service = :test
 
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { :host => 'http://localhost:3000/' }

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,3 +1,7 @@
+# ActiveStorage is currently disabled, and this file is therefore not loaded.
+# This file remains here so that it will be easier to configure ActiveStorage
+# if we decide to do so in the future.
+
 test:
   service: Disk
   root: <%= Rails.root.join("tmp/storage") %>


### PR DESCRIPTION
Open a PR and fill out the template later!


## Changelog
- Disabled ActiveStorage. It's currently not being used. If we did try to use it, it would currently work locally but not work in production until we set up an S3 bucket or other external storage service. Thus, it's preferable to disable it for now to silence the Heroku warning and make clear that it doesn't work.
- Note: the other warning listed in issue #54 has been addressed already in a different PR.


## Link to issue:  
Fixes #54 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
- N/A

## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added revelant screenshots
