### PR TITLE
Balance tooltip 406

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -77,3 +77,10 @@ a {
 .alert {
   margin-top: 1rem;
 }
+
+.tooltip > .tooltip-inner {
+  background-color: white;
+  color: black;
+  border: 1px solid $color-primary;
+  text-align: left;
+}

--- a/app/assets/stylesheets/lockbox_partners.scss
+++ b/app/assets/stylesheets/lockbox_partners.scss
@@ -1,6 +1,11 @@
 .lockbox-partner-header {
   margin: 0px auto;
 
+  .tooltip-icon {
+    color: $color-primary;
+    font-size: 0.6em;
+  }
+
   .lockbox-partner-info {
     p {
       width: 300px;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,5 +21,6 @@ require('../src/alerts');
 require('../src/notes');
 require('../src/admin_dashboard');
 require('../src/pending_support_requests_table');
+require('../src/tooltips');
 require('../src/transactions');
 require('../src/url_switching_select');

--- a/app/javascript/src/tooltips.js
+++ b/app/javascript/src/tooltips.js
@@ -1,0 +1,3 @@
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})

--- a/app/javascript/src/tooltips.js
+++ b/app/javascript/src/tooltips.js
@@ -1,3 +1,3 @@
-$(function () {
+document.addEventListener('turbolinks:load', () => {
   $('[data-toggle="tooltip"]').tooltip()
-})
+});

--- a/app/views/lockbox_partners/_header.html.erb
+++ b/app/views/lockbox_partners/_header.html.erb
@@ -11,6 +11,7 @@
         tabindex="0"
         data-toggle="tooltip"
         data-placement="bottom"
+        data-animation="false"
         title="The balance here includes all cash in the partner lockbox, minus any Pending Support Requests."
       >
       </i>

--- a/app/views/lockbox_partners/_header.html.erb
+++ b/app/views/lockbox_partners/_header.html.erb
@@ -6,6 +6,7 @@
   <h2>
     <%= lockbox_partner.name %>
     <span class="float-right">
+      <i class="fa fa-info-circle tooltip-icon"></i>
       <%= lockbox_partner.balance %>
     </span>
   </h2>

--- a/app/views/lockbox_partners/_header.html.erb
+++ b/app/views/lockbox_partners/_header.html.erb
@@ -6,7 +6,14 @@
   <h2>
     <%= lockbox_partner.name %>
     <span class="float-right">
-      <i class="fa fa-info-circle tooltip-icon"></i>
+      <i
+        class="fa fa-info-circle tooltip-icon"
+        tabindex="0"
+        data-toggle="tooltip"
+        data-placement="bottom"
+        title="The balance here includes all cash in the partner lockbox, minus any Pending Support Requests."
+      >
+      </i>
       <%= lockbox_partner.balance %>
     </span>
   </h2>

--- a/app/views/lockbox_partners/_header.html.erb
+++ b/app/views/lockbox_partners/_header.html.erb
@@ -15,7 +15,7 @@
         title="The balance here includes all cash in the partner lockbox, minus any Pending Support Requests."
       >
       </i>
-      <%= lockbox_partner.balance %>
+      $<%= lockbox_partner.balance %>
     </span>
   </h2>
   <div class="lockbox-partner-info">

--- a/bin/dev_setup
+++ b/bin/dev_setup
@@ -1,4 +1,4 @@
-#!/home/kevin/.rvm/rubies/ruby-2.6.5/bin/ruby -w
+#!/usr/bin/env ruby -w
 
 `bundle`
 if $?.success?

--- a/bin/dev_setup
+++ b/bin/dev_setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -w
+#!/home/kevin/.rvm/rubies/ruby-2.6.5/bin/ruby -w
 
 `bundle`
 if $?.success?


### PR DESCRIPTION
## Changelog
- Added tooltip to balance with explanatory text

## Link to issue:  
Fixes #406 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
![Screenshot_20200830_171526](https://user-images.githubusercontent.com/8214544/91670836-c82d2180-eae6-11ea-97dd-1912976b5109.png)

Note: It's not possible to make the background of the tooltip arrow white, because it's not possible to put borders on it. The way Bootstrap implements this, the borders of the tooltip are the triangular areas outside the arrow, so coloring the borders would color those entire areas.

## Are you ready for review?:

- [ ] Added relevant tests
- [x] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [x] Added relevant screenshots
