### PR TITLE
Refining system generated notes for support requests

### DIFF
--- a/app/controllers/lockbox_partners/support_requests_controller.rb
+++ b/app/controllers/lockbox_partners/support_requests_controller.rb
@@ -57,7 +57,11 @@ class LockboxPartners::SupportRequestsController < ApplicationController
     @lockbox_partner = @support_request.lockbox_partner
     require_admin_or_ownership
 
-    result = UpdateSupportRequest.call(support_request: @support_request, params: {lockbox_action_attributes: {id: @support_request.lockbox_action.id, status: update_status_params[:status]}})
+    result = UpdateSupportRequest.call(
+        support_request: @support_request,
+        params: {lockbox_action_attributes: {id: @support_request.lockbox_action.id, status: update_status_params[:status]}},
+        current_user: current_user
+    )
 
     if result.success?
       flash[:notice] = "Status updated to #{update_status_params[:status]}"
@@ -80,7 +84,7 @@ class LockboxPartners::SupportRequestsController < ApplicationController
     @support_request = SupportRequest.find(params[:id])
     @lockbox_partner = @support_request.lockbox_partner
 
-    result = UpdateSupportRequest.call(support_request: @support_request, params: support_request_params)
+    result = UpdateSupportRequest.call(support_request: @support_request, params: support_request_params, current_user: current_user)
 
     if result.success?
       flash[:notice] = "Support request was successfully updated"

--- a/lib/update_support_request.rb
+++ b/lib/update_support_request.rb
@@ -60,10 +60,10 @@ class UpdateSupportRequest
 
     original_values.each do |field, original_value|
       new_value = support_request.send(field)
-      next unless new_value != original_value
-
       new_value = 'blank' if new_value.blank?
       original_value = 'blank' if original_value.blank?
+      next unless new_value != original_value
+
       note_text << "The #{field_labels[field]} for this Support Request was changed from "\
                     "#{original_value} to #{new_value}."
     end

--- a/lib/update_support_request.rb
+++ b/lib/update_support_request.rb
@@ -27,7 +27,7 @@ class UpdateSupportRequest
   # }
   #
   # We'll pass it directly to SupportRequest to take advantage of AcceptsNestedAttributes.
-  input :support_request, :params
+  input :support_request, :params, optional: [:current_user]
 
   attr_accessor :support_request, :original_values
 
@@ -68,7 +68,7 @@ class UpdateSupportRequest
                     "#{original_value} to #{new_value}."
     end
 
-    note_text << "Changes made by #{support_request.user.name}." if support_request.user
+    note_text << "Changes made by #{current_user.display_name}." if current_user
     support_request.notes.create(text: note_text.join("\n"), notable_action: "update")
   end
 

--- a/lib/update_support_request.rb
+++ b/lib/update_support_request.rb
@@ -60,11 +60,15 @@ class UpdateSupportRequest
 
     original_values.each do |field, original_value|
       new_value = support_request.send(field)
-      if new_value != original_value
-        note_text << "The #{field_labels[field]} for this Support Request was changed from #{original_value} to #{new_value}"
-      end
+      next unless new_value != original_value
+
+      new_value = 'blank' if new_value.blank?
+      original_value = 'blank' if original_value.blank?
+      note_text << "The #{field_labels[field]} for this Support Request was changed from "\
+                    "#{original_value} to #{new_value}."
     end
 
+    note_text << "Changes made by #{support_request.user.name}." if support_request.user
     support_request.notes.create(text: note_text.join("\n"), notable_action: "update")
   end
 

--- a/spec/lib/update_support_request_spec.rb
+++ b/spec/lib/update_support_request_spec.rb
@@ -77,6 +77,7 @@ describe UpdateSupportRequest do
       .to change{Note.count}
       .by(1)
     expect(Note.last.text).to include("The Total Amount for this Support Request was changed")
+    expect(Note.last.text).to include("Changes made by #{support_request.user.name}.")
   end
 
   it 'creates a note if the pickup date has changed' do
@@ -91,6 +92,7 @@ describe UpdateSupportRequest do
       .to change{Note.count}
       .by(1)
     expect(Note.last.text).to include("The Pickup Date for this Support Request was changed")
+    expect(Note.last.text).to include("Changes made by #{support_request.user.name}.")
   end
 
   it 'creates a note if the status has changed' do
@@ -105,6 +107,7 @@ describe UpdateSupportRequest do
       .to change{Note.count}
       .by(1)
     expect(Note.last.text).to include("The Status for this Support Request was changed")
+    expect(Note.last.text).to include("Changes made by #{support_request.user.name}.")
   end
 
   it 'creates a note with notable_action of "update"' do
@@ -122,6 +125,7 @@ describe UpdateSupportRequest do
   end
 
   it 'creates a single note if multiple fields changed' do
+
     expect{UpdateSupportRequest.call(support_request: support_request, params: {client_ref_id: 'new client ref', name_or_alias: 'new name', urgency_flag: 'new urgency'})}
       .to change{Note.count}
       .by(1)
@@ -129,7 +133,8 @@ describe UpdateSupportRequest do
     note = Note.last
     expect(note.text).to include("The Client Reference ID for this Support Request was changed")
     expect(note.text).to include("The Client Alias for this Support Request was changed")
-    expect(note.text).to include("The Urgency Flag for this Support Request was changed")
+    expect(note.text).to include("The Urgency Flag for this Support Request was changed from blank to new urgency.")
+    expect(note.text).to include("Changes made by #{support_request.user.name}.")
   end
 
   it "does not succeed if the support request can't be updated" do

--- a/spec/lib/update_support_request_spec.rb
+++ b/spec/lib/update_support_request_spec.rb
@@ -73,7 +73,7 @@ describe UpdateSupportRequest do
       }
     }
 
-    expect{UpdateSupportRequest.call(support_request: support_request, params: update_params)}
+    expect{UpdateSupportRequest.call(support_request: support_request, params: update_params, current_user: support_request.user)}
       .to change{Note.count}
       .by(1)
     expect(Note.last.text).to include("The Total Amount for this Support Request was changed")
@@ -88,7 +88,7 @@ describe UpdateSupportRequest do
       }
     }
 
-    expect{UpdateSupportRequest.call(support_request: support_request, params: update_params)}
+    expect{UpdateSupportRequest.call(support_request: support_request, params: update_params, current_user: support_request.user)}
       .to change{Note.count}
       .by(1)
     expect(Note.last.text).to include("The Pickup Date for this Support Request was changed")
@@ -103,7 +103,7 @@ describe UpdateSupportRequest do
       }
     }
 
-    expect{UpdateSupportRequest.call(support_request: support_request, params: update_params)}
+    expect{UpdateSupportRequest.call(support_request: support_request, params: update_params, current_user: support_request.user)}
       .to change{Note.count}
       .by(1)
     expect(Note.last.text).to include("The Status for this Support Request was changed")
@@ -118,7 +118,7 @@ describe UpdateSupportRequest do
       }
     }
 
-    expect{UpdateSupportRequest.call(support_request: support_request, params: update_params)}
+    expect{UpdateSupportRequest.call(support_request: support_request, params: update_params, current_user: support_request.user)}
       .to change{Note.count}
       .by(1)
     expect(Note.last.notable_action).to eq("update")
@@ -126,7 +126,7 @@ describe UpdateSupportRequest do
 
   it 'creates a single note if multiple fields changed' do
 
-    expect{UpdateSupportRequest.call(support_request: support_request, params: {client_ref_id: 'new client ref', name_or_alias: 'new name', urgency_flag: 'new urgency'})}
+    expect{UpdateSupportRequest.call(support_request: support_request, params: {client_ref_id: 'new client ref', name_or_alias: 'new name', urgency_flag: 'new urgency'}, current_user: support_request.user)}
       .to change{Note.count}
       .by(1)
 


### PR DESCRIPTION
## Changelog
- Add punctuation at the end of each change noted in the update summary note text
- Include "Changes made by ___" in note text
- Displays "blank" for changes to and from nil/empty string values


## Link to issue:  
#368 


## Steps for QA/Special Notes:
Sign in as admin and edit support requests to see generated notes

## Relevant Screenshots: 
<img width="995" alt="Screen Shot 2020-09-20 at 3 06 17 PM" src="https://user-images.githubusercontent.com/34173394/93723926-a3f9b900-fb57-11ea-907d-3dff2d199b0a.png">


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
