### PR TITLE
Fix support request controller spec time zone flake

### DIFF
--- a/spec/controllers/support_requests_controller_spec.rb
+++ b/spec/controllers/support_requests_controller_spec.rb
@@ -4,8 +4,8 @@ describe SupportRequestsController do
 
   describe "#index" do
     context "when the user is an admin" do
+      let(:user) { create(:user) }
       it "returns 200" do
-        user = create(:user, role: User::ADMIN)
         sign_in(user)
         get :index
         expect(response.status).to eq(200)
@@ -13,8 +13,8 @@ describe SupportRequestsController do
     end
 
     context "when the user is not an admin" do
+      let(:user) { create(:user, :partner_user) }
       it "returns 302" do
-        user = create(:user, role: User::PARTNER)
         sign_in(user)
         get :index
         expect(response).to redirect_to(root_path)
@@ -23,25 +23,25 @@ describe SupportRequestsController do
   end
 
   describe '#export' do
-    let(:csv_string) { SupportRequest.to_csv }
+    let(:csv_string) { Time.use_zone(user.time_zone) { SupportRequest.to_csv } }
 
     before do
-      FactoryBot.create(:support_request, :pending)
-      FactoryBot.create(:support_request, :completed)
+      create(:support_request, :pending)
+      create(:support_request, :completed)
     end
 
     context 'when user is admin' do
+      let(:user) { create(:user) }
       it 'should return a csv attachment' do
-        admin_user = create(:user, role: User::ADMIN)
-        sign_in(admin_user)
+        sign_in(user)
         get :export, format: 'csv'
         expect(response.parsed_body).to eq(csv_string)
       end
     end
 
     context 'when user is not admin' do
+      let(:user) { create(:user, :partner_user) }
       it 'should return a csv attachment' do
-        user = create(:user, role: User::PARTNER)
         sign_in(user)
         get :export, format: 'csv'
         expect(response.parsed_body).to have_content('You are being')


### PR DESCRIPTION
To reproduce this spec error (https://app.circleci.com/pipelines/github/MidwestAccessCoalition/lockbox_rails/1137/workflows/2715855b-e551-448a-acb8-396a3f7ca7bc/jobs/1326), run support_requests_controller_spec in current trunk with the following inserted at line 31 `Timecop.travel(DateTime.new(2020, 10, 20, 0, 30, 0))`

`SupportRequest.to_csv` is computed in UTC when called on line 26, but when we call #export in the spec it's being computed in the Chicago time zone (user factory always sets Chicago time zone). This will make the spec fail for 5 hours every day from 7 pm to midnight Chicago time.

The fix is on line 26 of this PR, ensuring that the test string is being computed in the user's time zone. The rest is just cleaning up calls to user factories.