### PR TITLE
Reduce production log level to :info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,9 +46,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # Do not use :debug in production. This is a precaution to avoid writing note
+  # text and email body to the logs.
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
Open a PR and fill out the template later!


## Changelog
- Change global log level from `debug` to `info`. This will prevent the bodies of sent emails from being logged, as well as the values written to the database in `INSERT INTO` statements.


## Link to issue:  
Fixes #468


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
- super important for UI tasks!


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
