### PR TITLE
Adding break-word for text overflow in alerts

### DIFF
--- a/app/assets/stylesheets/alert.scss
+++ b/app/assets/stylesheets/alert.scss
@@ -6,7 +6,3 @@
   max-width: 600px;
   padding: 0;
 }
-
-.break-word {
-  word-break: break-word;
-}

--- a/app/assets/stylesheets/alert.scss
+++ b/app/assets/stylesheets/alert.scss
@@ -6,3 +6,7 @@
   max-width: 600px;
   padding: 0;
 }
+
+.break-word {
+  word-break: break-word;
+}

--- a/app/views/lockbox_partners/_admin_alerts.html.erb
+++ b/app/views/lockbox_partners/_admin_alerts.html.erb
@@ -4,7 +4,7 @@
       <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div class="break-word"><%= lockbox_partner.name %> has not confirmed cash in <%= lockbox_partner.pending_cash_addition_age %> days. Please check in with them for confirmation.</div>
+      <div class="text-break"><%= lockbox_partner.name %> has not confirmed cash in <%= lockbox_partner.pending_cash_addition_age %> days. Please check in with them for confirmation.</div>
     </div>
   </div>
 <% end %>
@@ -14,7 +14,7 @@
       <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div class="break-word"><%= lockbox_partner.name %>'s balance of $<%= lockbox_partner.balance %> is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. Please replenish the funds.</div>
+      <div class="text-break"><%= lockbox_partner.name %>'s balance of $<%= lockbox_partner.balance %> is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. Please replenish the funds.</div>
     </div>
   </div>
 <% end %>
@@ -24,7 +24,7 @@
       <i class="fa fa-check-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div class="break-word"><%= lockbox_partner.name %> has confirmed their cash is received, and you can now send them <%= link_to "Support Requests", new_lockbox_partner_support_request_path(lockbox_partner) %>.</div>
+      <div class="text-break"><%= lockbox_partner.name %> has confirmed their cash is received, and you can now send them <%= link_to "Support Requests", new_lockbox_partner_support_request_path(lockbox_partner) %>.</div>
     </div>
   </div>
 <% end %>

--- a/app/views/lockbox_partners/_admin_alerts.html.erb
+++ b/app/views/lockbox_partners/_admin_alerts.html.erb
@@ -4,7 +4,7 @@
       <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div><%= lockbox_partner.name %> has not confirmed cash in <%= lockbox_partner.pending_cash_addition_age %> days. Please check in with them for confirmation.</div>
+      <div class="break-word"><%= lockbox_partner.name %> has not confirmed cash in <%= lockbox_partner.pending_cash_addition_age %> days. Please check in with them for confirmation.</div>
     </div>
   </div>
 <% end %>
@@ -14,7 +14,7 @@
       <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div><%= lockbox_partner.name %>'s balance of $<%= lockbox_partner.balance %> is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. Please replenish the funds.</div>
+      <div class="break-word"><%= lockbox_partner.name %>'s balance of $<%= lockbox_partner.balance %> is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. Please replenish the funds.</div>
     </div>
   </div>
 <% end %>
@@ -24,7 +24,7 @@
       <i class="fa fa-check-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div><%= lockbox_partner.name %> has confirmed their cash is received, and you can now send them <%= link_to "Support Requests", new_lockbox_partner_support_request_path(lockbox_partner) %>.</div>
+      <div class="break-word"><%= lockbox_partner.name %> has confirmed their cash is received, and you can now send them <%= link_to "Support Requests", new_lockbox_partner_support_request_path(lockbox_partner) %>.</div>
     </div>
   </div>
 <% end %>

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="p-2 flex-grow-1">
       <h4 class="alert-heading">Reconciliation Due</h4>
-      <div>It's been <%= days_since_last_reconciliation %> days since the lockbox has been reconciled. Please count the cash in the box and record the total.</div>
+      <div class="break-word">It's been <%= days_since_last_reconciliation %> days since the lockbox has been reconciled. Please count the cash in the box and record the total.</div>
     </div>
     <div class="p-2">
       <%= link_to "Reconcile Budget", new_lockbox_partner_reconciliation_path(lockbox_partner), class: 'btn btn-danger' %>
@@ -21,7 +21,7 @@
       </div>
       <div class="p-2 flex-grow-1">
         <h4 class="alert-heading">Cash Sent</h4>
-        <div>A $<%= cash_action.amount %> check was mailed on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.</div>
+        <div class="break-word">A $<%= cash_action.amount %> check was mailed on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.</div>
 
         <% if cash_action.tracking_info.present? %>
           <div>Tracking info: <%= cash_action.tracking_info_formatted %></div>
@@ -41,7 +41,7 @@
       <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div>
+      <div class="break-word">
         Your lockbox balance is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email <%= link_to alert_email, "mailto:#{alert_email}" %>.
       </div>
     </div>

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="p-2 flex-grow-1">
       <h4 class="alert-heading">Reconciliation Due</h4>
-      <div class="break-word">It's been <%= days_since_last_reconciliation %> days since the lockbox has been reconciled. Please count the cash in the box and record the total.</div>
+      <div class="text-break ">It's been <%= days_since_last_reconciliation %> days since the lockbox has been reconciled. Please count the cash in the box and record the total.</div>
     </div>
     <div class="p-2">
       <%= link_to "Reconcile Budget", new_lockbox_partner_reconciliation_path(lockbox_partner), class: 'btn btn-danger' %>
@@ -21,7 +21,7 @@
       </div>
       <div class="p-2 flex-grow-1">
         <h4 class="alert-heading">Cash Sent</h4>
-        <div class="break-word">A $<%= cash_action.amount %> check was mailed on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.</div>
+        <div class="text-break ">A $<%= cash_action.amount %> check was mailed on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.</div>
 
         <% if cash_action.tracking_info.present? %>
           <div>Tracking info: <%= cash_action.tracking_info_formatted %></div>
@@ -41,7 +41,7 @@
       <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div class="break-word">
+      <div class="text-break ">
         Your lockbox balance is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email <%= link_to alert_email, "mailto:#{alert_email}" %>.
       </div>
     </div>


### PR DESCRIPTION
## Changelog
- Added css to "break words" if the text overflows


## Link to issue:  
Fixes issue #483 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 

Before:
<img width="290" alt="before" src="https://user-images.githubusercontent.com/34173394/101295840-e173f700-37d4-11eb-84cb-9567d4e3b5ae.png">
After: 
<img width="286" alt="after" src="https://user-images.githubusercontent.com/34173394/101295839-dfaa3380-37d4-11eb-8f4b-1660ac73ff77.png">




## Are you ready for review?:

- [ ] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
