### PR TITLE
[Issue-482] Fix for support request add-note form mobile display bug

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -46,7 +46,7 @@ a {
 .table {
   margin-top: 20px;
   thead {
-    background-color: #dee2e6;
+    background-color: $light-gray;
   }
 }
 

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -98,7 +98,8 @@
   font-weight: bolder;
 }
 
-.btn-primary.view-half, .btn-secondary.view-half {
+.btn-primary.view-half,
+.btn-secondary.view-half {
   position: relative;
   display: flex;
   justify-content: center;

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -12,7 +12,7 @@
     margin: 10px;
     margin-top: 0px;
   }
-  a.btn-primary.view-full {
+  .btn-primary.view-full {
     border: none;
     &:hover {
       background-color: $darker-blue;
@@ -102,15 +102,16 @@ $note-form-color: #d6d7d9;
     background: $note-form-color;
     .container {
       padding: 20px;
+      div {
+        max-width: 480px;
+      }
     }
     .textarea {
-      width: 500px;
       textarea {
         height: 180px;
       }
     }
     .buttons {
-      width: 500px;
       height: 39px;
       padding: 10px;
       * {
@@ -187,9 +188,9 @@ $note-form-color: #d6d7d9;
   justify-content: space-between;
 }
 .support-request-nav-item {
-  background-color: $gray;
-  border-top: 1px solid black;
-  border-right: 1px solid black;
+  background-color: $light-gray;
+  border-top: 1px solid $black;
+  border-right: 1px solid $black;
   padding: 20px;
   display: inline;
   flex: 1 auto;

--- a/app/assets/stylesheets/support_request.scss
+++ b/app/assets/stylesheets/support_request.scss
@@ -106,10 +106,8 @@ $note-form-color: #d6d7d9;
         max-width: 480px;
       }
     }
-    .textarea {
-      textarea {
-        height: 180px;
-      }
+    .textarea textarea {
+      height: 180px;
     }
     .buttons {
       height: 39px;

--- a/app/javascript/src/notes.js
+++ b/app/javascript/src/notes.js
@@ -4,7 +4,7 @@ const addNewNote = note => {
 };
 
 const openNoteForm = () => {
-  $('#new-note-form').slideDown(250);
+  $('#new-note-form').slideDown(100);
   $('#new-note')
     .parent()
     .addClass('selected');
@@ -14,17 +14,17 @@ const openNoteForm = () => {
 const displayNoteSuccess = text => {
   $('#note-success #note-event').text('New note created');
   $('#note-success #note-text').text(text);
-  $('#note-success').slideDown(250);
+  $('#note-success').slideDown(100);
 };
 
 const displayNoteUpdate = text => {
   $('#note-success #note-event').text('Note updated');
   $('#note-success #note-text').text(text);
-  $('#note-success').slideDown(250);
+  $('#note-success').slideDown(100);
 };
 
 const hideNoteSuccess = () => {
-  $('#note-success').slideUp(250);
+  $('#note-success').slideUp(100);
   clearHighlights();
 };
 
@@ -42,7 +42,7 @@ const highlightNote = note => {
 };
 
 const clearNoteForm = () => {
-  $('#new-note-form').slideUp(250);
+  $('#new-note-form').slideUp(100);
   $('#new-note-form textarea').val('');
 };
 

--- a/app/views/lockbox_partners/support_requests/show.html.erb
+++ b/app/views/lockbox_partners/support_requests/show.html.erb
@@ -7,13 +7,19 @@
     <% if current_user.admin? %>
       <%= render partial: 'details_admin', locals: { support_request: @support_request } %>
       <div class="tabs">
-        <div class="tab"><%= link_to 'Edit Support Request', edit_lockbox_partner_support_request_path(@support_request.lockbox_partner, @support_request), class: 'btn btn-primary', disabled: !@support_request.editable_status? %></div>
-        <div class="tab"><%= link_to 'Add Note', '#', class: 'btn btn-secondary', id: 'new-note' %></div>
+        <div class="tab">
+          <%= link_to 'Edit Support Request', edit_lockbox_partner_support_request_path(@support_request.lockbox_partner, @support_request), class: 'btn btn-primary', disabled: !@support_request.editable_status? %>
+        </div>
+        <div class="tab">
+          <button id="new-note" class="btn btn-secondary">Add Note</button>
+        </div>
       </div>
     <% else %>
       <%= render partial: 'details_partner', locals: { support_request: @support_request } %>
       <ul class="tabs">
-        <li class="tab"><%= link_to 'Add Note', '#', class: 'btn btn-primary', id: 'new-note' %></li>
+        <li class="tab">
+          <button id="new-note" class="btn btn-primary">Add Note</button>
+        </li>
       </ul>
     <% end %>
 

--- a/spec/controllers/lockbox_partners/support_requests_controller_spec.rb
+++ b/spec/controllers/lockbox_partners/support_requests_controller_spec.rb
@@ -89,6 +89,7 @@ describe LockboxPartners::SupportRequestsController do
     it 'updates in less than 1/40th of a second' do
       sign_in(user)
       expect(NoteMailer).not_to receive(:deliver_note_creation_alerts)
+      # This is kinda flaky -- might be better to make the call 10 times and take an average.
       expect {
         post :update_status, params: {
           lockbox_partner_id: support_request.lockbox_partner_id,

--- a/spec/system/lockbox_partner_pagination_spec.rb
+++ b/spec/system/lockbox_partner_pagination_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "LockboxPartner show page", type: :system do
     create(:support_request, :pending, lockbox_partner: lockbox_partner)
     visit("/lockbox_partners/#{lockbox_partner.id}")
     page.assert_selector(".support-request-container ul.pagination", count: 1)
+    # TODO: investigate why this test is so flaky (often only finds 19)
     page.assert_selector(".support-request-container .lockbox-activity tr.pending", count: 20)
     click_link("2")
     page.assert_selector(".support-request-container .lockbox-activity tr.completed", count: 1)

--- a/spec/system/support_request_actions_spec.rb
+++ b/spec/system/support_request_actions_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe "Support Request Actions", type: :system do
   it 'successfully view, edit, and add notes to a support request' do
     visit "/lockbox_partners/#{lockbox_partner.id}/support_requests/#{support_request.id}"
     assert_selector "h3", text: "Support Request for Leafy Greens"
-    click_link "Add Note"
+    click_button "Add Note"
+
     fill_in "note_text", with: "Here's some fine & fancy note text!"
     sleep(1)
     # Sleep for 1 second to avoid a race condition in slower environments (e.g., CircleCI)

--- a/spec/system/support_request_creation_spec.rb
+++ b/spec/system/support_request_creation_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe "Support Request Creation", type: :system do
 
     assert_selector "h3", text: "Support Request for"
 
-    click_link "Add Note"
+    click_button "Add Note"
+
     fill_in "note_text", with: "Here's some fine & fancy note text!"
 
     sleep(1)
@@ -48,7 +49,8 @@ RSpec.describe "Support Request Creation", type: :system do
 
     assert_selector "h3", text: "Support Request for"
 
-    click_link "Add Note"
+    click_button "Add Note"
+
     fill_in "note_text", with: "Here's some fine & fancy note text!"
 
     sleep(1)


### PR DESCRIPTION
## Changelog
* change width to max-width for add-note form textarea and buttons
* minor style/UX improvements encountered during local dev

## Link to issue:  
#482 

## Relevant Screenshots: 
<img width="852" alt="Screen Shot 2020-12-06 at 8 18 41 PM" src="https://user-images.githubusercontent.com/6441226/101302071-485ad580-3800-11eb-9fba-6b79ab4b8196.png">
<img width="330" alt="Screen Shot 2020-12-06 at 8 18 48 PM" src="https://user-images.githubusercontent.com/6441226/101302073-48f36c00-3800-11eb-9805-3135941a1699.png">

## Are you ready for review?:
- [x] Linked PR to the issue
- [x] Added relevant screenshots
