### PR TITLE
Hide nav bar if text becomes too squished on small screens

### DIFF
--- a/app/assets/stylesheets/secondary_nav.scss
+++ b/app/assets/stylesheets/secondary_nav.scss
@@ -4,6 +4,11 @@ $secondary-tab: $darker-blue;
 $secondary-active-tab: #1f5593;
 
 .secondary-nav {
+  @media only screen and (max-width: 600px) {
+    // hide nav bar if the text becomes too squished
+    display: none;
+  }
+
   .secondary-nav-tabs {
     display: flex;
     height: 2rem;


### PR DESCRIPTION
## Changelog
- Added CSS to hide nav bar for smaller screens

(Options are already under "quick actions")


## Link to issue:  
Fixes issue #481 


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
<img width="469" alt="Screen Shot 2020-12-13 at 2 50 33 PM" src="https://user-images.githubusercontent.com/34173394/102026465-d9770280-3d52-11eb-878f-30558fca1454.png">



## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added relevant screenshots
