### PR TITLE
Update css for alert buttons (reconcile/confirm cash) on mobile

### DIFF
--- a/app/assets/stylesheets/alert.scss
+++ b/app/assets/stylesheets/alert.scss
@@ -6,3 +6,30 @@
   max-width: 600px;
   padding: 0;
 }
+
+@media only screen and (max-width: 500px) {
+  .center-button {
+    text-align: center;
+  }
+}
+
+.alert-header-and-link {
+  justify-content: space-between;
+  align-content: center;
+  .btn-warning {
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+
+  @media only screen and (min-width: 500px) {
+    display: flex;
+    .btn-warning {
+      margin: 0;
+    }
+
+    .max-width-75 {
+      max-width: 75%;
+    }
+  }
+}
+

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -1,34 +1,42 @@
 <% if lockbox_partner.reconciliation_needed? %>
-  <div class="alert alert-danger d-flex">
-    <div class="p-2">
-      <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
-    </div>
-    <div class="p-2 flex-grow-1">
-      <h4 class="alert-heading">Reconciliation Due</h4>
-      <div class="text-break ">It's been <%= days_since_last_reconciliation %> days since the lockbox has been reconciled. Please count the cash in the box and record the total.</div>
-    </div>
-    <div class="p-2">
-      <%= link_to "Reconcile Budget", new_lockbox_partner_reconciliation_path(lockbox_partner), class: 'btn btn-danger' %>
+  <div class="alert alert-danger">
+    <div class="alert-header-and-link">
+      <div class="d-flex max-width-75">
+        <i class="fa fa-exclamation-circle alert-primary-icon p-2" aria-hidden="true"></i>
+        <div class="p-2 flex-grow-1">
+          <h4 class="alert-heading">Reconciliation Due</h4>
+          <div class="text-break">It's been <%= days_since_last_reconciliation %> days since the lockbox has been
+            reconciled. Please count the cash in the box and record the total.
+          </div>
+        </div>
+      </div>
+      <div class="p-2 center-button">
+        <%= link_to "Reconcile Budget", new_lockbox_partner_reconciliation_path(lockbox_partner), class: 'btn btn-danger' %>
+      </div>
     </div>
   </div>
 <% end %>
 
 <% if lockbox_partner.cash_addition_confirmation_pending? %>
   <% lockbox_partner.lockbox_actions.pending_cash_additions.each do |cash_action| %>
-    <div class="alert alert-warning d-flex">
-      <div class="p-2">
-        <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
-      </div>
-      <div class="p-2 flex-grow-1">
-        <h4 class="alert-heading">Cash Sent</h4>
-        <div class="text-break ">A $<%= cash_action.amount %> check was mailed on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.</div>
+    <div class="alert alert-warning">
+      <div class="alert-header-and-link">
+        <div class="d-flex max-width-75">
+          <i class="fa fa-exclamation-circle alert-primary-icon p-2" aria-hidden="true"></i>
+          <div class="p-2 flex-grow-1 max-width-75">
+            <h4 class="alert-heading">Cash Sent</h4>
+            <div class="text-break">A $<%= cash_action.amount %> check was mailed
+              on <%= cash_action.eff_date.try(:strftime, "%B %-d") %>, please confirm it was received.
+            </div>
 
-        <% if cash_action.tracking_info.present? %>
-          <div>Tracking info: <%= cash_action.tracking_info_formatted %></div>
-        <% end %>
-      </div>
-      <div class="p-2">
-        <%= link_to "Confirm Cash Addition", lockbox_action_path(cash_action, {lockbox_action: {status: :completed}}), method: :put, class: 'btn btn-warning' %>
+            <% if cash_action.tracking_info.present? %>
+              <div>Tracking info: <%= cash_action.tracking_info_formatted %></div>
+            <% end %>
+          </div>
+        </div>
+        <div class="p-2 center-button">
+          <%= link_to "Confirm Cash Addition", lockbox_action_path(cash_action, {lockbox_action: {status: :completed}}), method: :put, class: 'btn btn-warning' %>
+        </div>
       </div>
     </div>
   <% end %>
@@ -41,7 +49,7 @@
       <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div class="text-break ">
+      <div class="text-break">
         Your lockbox balance is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email <%= link_to alert_email, "mailto:#{alert_email}" %>.
       </div>
     </div>


### PR DESCRIPTION

## Changelog
- Update css for alert buttons (reconcile/confirm cash) on mobile


## Link to issue:  
Fixes issue #529


## Steps for QA/Special Notes:
- Check alerts on different screen sizes (like mobile)

## Relevant Screenshots: 
(Desktop)
<img width="1192" alt="Screen Shot 2020-12-13 at 3 26 06 PM" src="https://user-images.githubusercontent.com/34173394/102027881-e4826080-3d5b-11eb-8247-b31b56a463bb.png">

(Mobile)
<img width="490" alt="Screen Shot 2020-12-13 at 3 26 19 PM" src="https://user-images.githubusercontent.com/34173394/102027886-ec420500-3d5b-11eb-8651-fc92fa3523e2.png">

## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added relevant screenshots
