### PR TITLE
Make dashboard tables more responsive and fix support requests dashboard buttons

### DIFF
--- a/app/views/admin_dashboard/index.html.erb
+++ b/app/views/admin_dashboard/index.html.erb
@@ -18,6 +18,6 @@
 <% end %>
 <div class="horizontal-rule"></div>
 <h3>Manage users</h3>
-<div class="admin-dashboard-users-wrapper">
+<div class="admin-dashboard-users-wrapper table-responsive">
   <%= render partial: 'users', locals: { users: @users } %>
 </div>

--- a/app/views/lockbox_partners/users/index.html.erb
+++ b/app/views/lockbox_partners/users/index.html.erb
@@ -1,8 +1,8 @@
 <%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
 <%= render partial: 'new', locals: { lockbox_partner: @lockbox_partner, new_user: @new_user } %>
 <hr />
-<div class="all-users">
-  <h3>Manage users</h3>
+<h3>Manage users</h3>
+<div class="all-users table-responsive">
   <table class="table">
     <thead>
       <tr>

--- a/app/views/support_requests/index.html.erb
+++ b/app/views/support_requests/index.html.erb
@@ -1,16 +1,18 @@
-<div class="container">
-  <div id="support-requests-index">
-    <h2>Welcome, <%= current_user.name %>!</h2>
+<div id="support-requests-index">
+  <h2>Welcome, <%= current_user.name %>!</h2>
+  <div class="lockbox-partner-buttons">
     <%= link_to 'File a support request', support_requests_new_path, class: 'btn btn-primary view-half' %>
     <%= link_to 'Add a new lockbox partner', new_lockbox_partner_path, class: 'btn btn-secondary view-half float-right' %>
-    <div class="horizontal-rule"></div>
-    <p>
-    <strong>Current View:</strong>
-    <%= render 'shared/url_switching_select', options: [
-      ['Lockbox Partners', root_path],
-      ['Pending Support Requests', support_requests_path]
-    ], selected_value: support_requests_path %>
-    </p>
+  </div>
+  <div class="horizontal-rule"></div>
+  <p>
+  <strong>Current View:</strong>
+  <%= render 'shared/url_switching_select', options: [
+    ['Lockbox Partners', root_path],
+    ['Pending Support Requests', support_requests_path]
+  ], selected_value: support_requests_path %>
+  </p>
+  <div class="table-responsive">
     <table class="table" id="supportRequestsTable">
       <thead>
         <tr>


### PR DESCRIPTION
## Changelog
add table-responsive to admin dashboard users table and support requests table, previously added to several other tables. in passing, fixed the buttons at the top of support requests page

## Link to issue:  
https://github.com/MidwestAccessCoalition/lockbox_rails/issues/478

## Relevant Screenshots: 
before
<img width="342" alt="Screen Shot 2021-01-17 at 4 13 55 PM" src="https://user-images.githubusercontent.com/4739591/104857577-19478180-58df-11eb-9597-7bd5642ff91c.png">
after
<img width="343" alt="Screen Shot 2021-01-17 at 4 14 18 PM" src="https://user-images.githubusercontent.com/4739591/104857579-1c427200-58df-11eb-97a5-449461e91ed8.png">

## Are you ready for review?:
- [x] Linked PR to the issue
- [x] Added relevant screenshots
