### PR TITLE
541 gas reinbursements

### DIFF
--- a/app/javascript/src/transactions.js
+++ b/app/javascript/src/transactions.js
@@ -52,9 +52,11 @@ const rowFromGas = row => {
   }
 };
 
+const gasSelectName = "gas_reimbursements"
+
 const updateTransaction = select => {
   const row = $(select).parents('.row');
-  if (select.value == 'gas') {
+  if (select.value == gasSelectName) {
     rowToGas(row);
   } else {
     rowFromGas(row);

--- a/spec/system/support_request_creation_spec.rb
+++ b/spec/system/support_request_creation_spec.rb
@@ -65,4 +65,15 @@ RSpec.describe "Support Request Creation", type: :system do
     assert_no_selector "h2", text: "New support request"
     assert_selector "p", text: "Lockbox partner not yet active"
   end
+
+  it 'computes gas reinbursement rate' do
+    visit "/support_requests/new"
+
+    page.assert_selector('.distance-field', visible: true, count: 0)
+    page.all(:option, "Gas reimbursements").first.select_option
+    page.assert_selector('.distance-field', visible: true, count: 1)
+
+    fill_in "Mileage", with: 42
+    assert_selector "legend", text: "Total: $8.40"
+  end
 end


### PR DESCRIPTION
## Changelog
The gas reimbursement option had been changed from "gas" to "gas_reimbursement", breaking the mileage calculator. Fixed and added system spec.

## Link to issue: https://github.com/MidwestAccessCoalition/lockbox_rails/issues/541

## Steps for QA/Special Notes:
Open a support_requests#new form and select gas reimbursements for one of the transactions

## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
