### PR TITLE
1/2 Add new minimum_acceptable_balance column with default value of 50000

### DIFF
--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -1,4 +1,6 @@
 class LockboxPartner < ApplicationRecord
+  after_initialize :set_defaults
+
   has_many :users
   has_many :lockbox_actions
   has_many :support_requests, dependent: :destroy
@@ -26,6 +28,10 @@ class LockboxPartner < ApplicationRecord
   scope :with_initial_cash, -> do
     # returns partners that have had cash successfully added at least once
     includes(:lockbox_actions).merge(LockboxAction.completed_cash_additions).references(:lockbox_actions)
+  end
+
+  def set_defaults
+    self.minimum_acceptable_balance ||= MINIMUM_ACCEPTABLE_BALANCE
   end
 
   def pending_support_requests

--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -46,6 +46,8 @@ class LockboxPartner < ApplicationRecord
 
   def low_balance?
     balance < MINIMUM_ACCEPTABLE_BALANCE
+    # TODO after backfill
+    # balance.cents < minimum_acceptable_balance
   end
 
   def insufficient_funds?

--- a/db/migrate/20210117223939_add_minimum_acceptable_balance_to_lockbox_partners.rb
+++ b/db/migrate/20210117223939_add_minimum_acceptable_balance_to_lockbox_partners.rb
@@ -1,0 +1,5 @@
+class AddMinimumAcceptableBalanceToLockboxPartners < ActiveRecord::Migration[6.0]
+  def change
+    add_column :lockbox_partners, :minimum_acceptable_balance, :integer, default: 50000
+  end
+end

--- a/db/migrate/20210117223939_add_minimum_acceptable_balance_to_lockbox_partners.rb
+++ b/db/migrate/20210117223939_add_minimum_acceptable_balance_to_lockbox_partners.rb
@@ -1,5 +1,5 @@
 class AddMinimumAcceptableBalanceToLockboxPartners < ActiveRecord::Migration[6.0]
   def change
-    add_column :lockbox_partners, :minimum_acceptable_balance, :integer, default: 50000
+    add_column :lockbox_partners, :minimum_acceptable_balance, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_06_230927) do
+ActiveRecord::Schema.define(version: 2021_01_17_223939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2020_12_06_230927) do
     t.string "state"
     t.string "zip_code"
     t.string "phone_ext"
+    t.integer "minimum_acceptable_balance"
   end
 
   create_table "lockbox_transactions", force: :cascade do |t|

--- a/spec/factories/lockbox_partners.rb
+++ b/spec/factories/lockbox_partners.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     state          { Faker::Address.state }
     zip_code       { Faker::Address.zip_code }
     phone_number   { (2..9).to_a.sample.to_s + Faker::Base.numerify('#########') }
+    minimum_acceptable_balance { 500_00 }
 
     trait :active do
       # The user needs to be confirmed, but currently the user factory does this


### PR DESCRIPTION

## Changelog
Adding a new column `minimum_acceptable_balance` with default value of 50000. 

This is the first part of #371 - if there are any issues migrating this column after it's being referenced, then it might leave the application in an unstable state. 


## Link to issue:  
#371 


## Steps for QA/Special Notes:
- This column is not used in this PR. It is just the migration

## Relevant Screenshots: 
- N/A


## Are you ready for review?:

- [ ] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [ ] Added relevant screenshots
