### PR TITLE
Prevent paper_trail from recording name_or_alias

### DIFF
--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -17,7 +17,8 @@ class SupportRequest < ApplicationRecord
 
   # Sometimes the UUID will already have been created elsewhere, and sometimes not
   before_validation :populate_client_ref_id
-  has_paper_trail
+  # Do not save possible PII to the versions table
+  has_paper_trail ignore: [:name_or_alias]
 
   # for grepability:
   # scope :pending

--- a/spec/models/support_request_spec.rb
+++ b/spec/models/support_request_spec.rb
@@ -268,4 +268,34 @@ describe SupportRequest, type: :model do
       expect(note3.reload.text).not_to eq(SupportRequest::REDACTED)
     end
   end
+
+  describe "paper_trail" do
+    let(:support_request) do
+      create(:support_request, name_or_alias: "old name", urgency_flag: "old flag")
+    end
+
+    context "on creation" do
+      it "does not record name_or_alias" do
+        expect(support_request.versions.first.object_changes).not_to include("old name")
+      end
+
+      it "does record other fields" do
+        expect(support_request.versions.first.object_changes).to include("old flag")
+      end
+    end
+
+    context "on update" do
+      before do
+        support_request.update!(name_or_alias: "new name", urgency_flag: "new flag")
+      end
+
+      it "does not record name_or_alias" do
+        expect(support_request.versions.last.object_changes).not_to include("new name")
+      end
+
+      it "does record other fields" do
+        expect(support_request.versions.last.object_changes).to include("new flag")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changelog
- Configure paper_trail to ignore the `support_requests.name_or_alias` column

## Link to issue:  
Fixes #555 

## Steps for QA/Special Notes:
I verified in the console that paper_trail doesn't record `name_or_alias` when a SupportRequest is created or updated. If an update changes only the `name_or_alias`, that update isn't recorded in the versions table at all, which I assume is fine.

We do not use paper_trail for notes, so this is the only field we need to be concerned about.

## Relevant Screenshots: 
- N/A


## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added relevant screenshots
