### PR TITLE
Fix - Adding menu items to hamburger nav when viewing a lockbox partner

### DIFF
--- a/app/views/layouts/_nav_bar.html.erb
+++ b/app/views/layouts/_nav_bar.html.erb
@@ -66,7 +66,7 @@
               <p class="heading">Quick Actions</p>
               <p><a href="<%= lockbox_partners_path %>">View all lockboxes</a></p>
               <p><a href="<%= support_requests_new_path %>">File a support request</a></p>
-              <% if @lockbox_partner && !current_page?(new_lockbox_partner_path) %>
+              <% if @lockbox_partner && @lockbox_partner.persisted? %>
                 <p><a href="<%= new_lockbox_partner_add_cash_path(@lockbox_partner) %>">Add cash to lockbox</a></p>
                 <p><a href="<%= lockbox_partner_users_path(@lockbox_partner) %>">Manage lockbox partner</a></p>
               <% end %>

--- a/app/views/layouts/_nav_bar.html.erb
+++ b/app/views/layouts/_nav_bar.html.erb
@@ -66,6 +66,10 @@
               <p class="heading">Quick Actions</p>
               <p><a href="<%= lockbox_partners_path %>">View all lockboxes</a></p>
               <p><a href="<%= support_requests_new_path %>">File a support request</a></p>
+              <% if @lockbox_partner && !current_page?(new_lockbox_partner_path) %>
+                <p><a href="<%= new_lockbox_partner_add_cash_path(@lockbox_partner) %>">Add cash to lockbox</a></p>
+                <p><a href="<%= lockbox_partner_users_path(@lockbox_partner) %>">Manage lockbox partner</a></p>
+              <% end %>
               <p><a href="<%= new_lockbox_partner_path %>">Add a new lockbox partner</a></p>
               <p><a href="<%= support_requests_export_path(:format => "csv") %>">Financial Export</a></p>
             <% end %>

--- a/spec/system/navbar_menu_spec.rb
+++ b/spec/system/navbar_menu_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe "Navbar menu", type: :system do
         page.assert_no_selector("#navbar-drawer")
       end
 
+      it "does not have secondary nav tabs" do
+        click_button("navbar-control")
+        page.assert_no_text("Add cash to lockbox")
+        page.assert_no_text("Manage lockbox partner")
+      end
+
+      it "has secondary nav tabs" do
+        visit("/lockbox_partners/#{lockbox_partner.id}")
+        click_button("navbar-control")
+        page.assert_text("Add cash to lockbox")
+        page.assert_text("Manage lockbox partner")
+      end
     end
   end
 


### PR DESCRIPTION

## Changelog
- Added conditional menu items when viewing the lockbox partner


## Link to issue:  
Fixes issue #559


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
(on home page)
<img width="526" alt="Screen Shot 2021-01-24 at 5 23 09 PM" src="https://user-images.githubusercontent.com/34173394/105650572-f716ac00-5e68-11eb-9a5f-4690ef9b939e.png">


(on lockbox page)
<img width="462" alt="Screen Shot 2021-01-24 at 5 23 50 PM" src="https://user-images.githubusercontent.com/34173394/105650590-0269d780-5e69-11eb-8d2c-405db3dd428c.png">


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
