### PR TITLE
Add extra user per lockbox partner to seeds for local testing

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,6 +34,13 @@ LOCKBOX_PARTNERS.map do |partner_name, partner_user_email|
     role: User::PARTNER
   )
 
+  User.where(email: Faker::Internet.email).first_or_create!(
+    lockbox_partner: lockbox_partner,
+    password: 'heytherefancypants4321',
+    confirmed_at: Time.current,
+    role: User::PARTNER
+  )
+
   lockbox_partner.lockbox_actions.create!(
     eff_date: Date.current - 1.week,
     action_type: LockboxAction::ADD_CASH,


### PR DESCRIPTION
This will ensure that the support request dropdown issue will be locally testable, should it return. low priority

Follow up from https://github.com/MidwestAccessCoalition/lockbox_rails/issues/369