### PR TITLE
Redact support requests closed exactly 90 days ago

### DIFF
--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -38,7 +38,7 @@ class SupportRequest < ApplicationRecord
         support_requests: { redacted: false },
         lockbox_actions: { status: LockboxAction::CLOSED_STATUSES }
       )
-      .where("lockbox_actions.closed_at < ?", REDACT_AFTER_DAYS.days.ago)
+      .where("lockbox_actions.closed_at <= ?", REDACT_AFTER_DAYS.days.ago)
   end
 
   def all_support_requests_for_partner


### PR DESCRIPTION
## Changelog
- Support requests will be included in the `needs_redaction` scope if they were created _exactly_ 90 days ago. This is probably the correct behavior (although it's unlikely to come up in prod) and fixes some intermittent test failures.

## Link to issue:  
Fixes issue #N/A


## Steps for QA/Special Notes:
- N/A

## Relevant Screenshots: 
- super important for UI tasks!


## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added relevant screenshots
