### PR TITLE
2/2 Added minimum_acceptable_balance field input on forms

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -24,6 +24,10 @@
   }
 }
 
+p.help-text {
+  color: $dark-gray;
+}
+
 #error_explanation {
   color: #721c24;
   background-color: #f8d7da;

--- a/app/assets/stylesheets/lockbox_partners.scss
+++ b/app/assets/stylesheets/lockbox_partners.scss
@@ -8,7 +8,7 @@
     .header-desktop { display: block; }
     .header-mobile { display: none; }
   }
-  
+
   .tooltip-icon {
     color: $color-primary;
     font-size: 0.6em;
@@ -23,7 +23,7 @@
   }
 }
 
-.lockbox-partner-buttons {
+.lockbox-partner-buttons, .lockbox-partner-header-info {
   display: flex;
   justify-content: space-between;
 }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -10,4 +10,5 @@ $color-primary-alert: #e1f3f8;
 $darker-blue: #194180;
 $gray: #dee2e6;
 $medium-dark-gray: rgb(207,208,210);
+$dark-gray: #6d757d;
 $light-gray: rgb(247,247,247);

--- a/app/controllers/lockbox_partners_controller.rb
+++ b/app/controllers/lockbox_partners_controller.rb
@@ -47,7 +47,7 @@ class LockboxPartnersController < ApplicationController
   def lockbox_params
     params.require(:lockbox_partner)
           .permit(:name, :phone_number, :phone_ext, :street_address,
-                  :city, :state, :zip_code)
+                  :city, :state, :zip_code, :minimum_acceptable_balance)
   end
 
   def set_lockbox_partner

--- a/app/javascript/src/form_validation.js
+++ b/app/javascript/src/form_validation.js
@@ -28,3 +28,15 @@ const submitButton = document.querySelectorAll('[type="submit"]')[0];
 submitButton.addEventListener("click", () => {
   removePristineFromInputs();
 });
+
+// Add field for displaying min acceptable balance
+const formatMinBalanceInput = () => {
+  const balanceSaved = document.getElementById("lockbox_partner_minimum_acceptable_balance");
+  const balanceInput = document.getElementById('minimum-acceptable-balance-formatted');
+  balanceInput.value = balanceSaved.value/100;
+  balanceInput.addEventListener("change", (event) => {
+    balanceSaved.value = balanceInput.value * 100;
+    console.log(balanceSaved.value);
+  })
+}
+formatMinBalanceInput();

--- a/app/javascript/src/form_validation.js
+++ b/app/javascript/src/form_validation.js
@@ -36,7 +36,6 @@ const formatMinBalanceInput = () => {
   balanceInput.value = balanceSaved.value/100;
   balanceInput.addEventListener("change", (event) => {
     balanceSaved.value = balanceInput.value * 100;
-    console.log(balanceSaved.value);
   })
 }
 formatMinBalanceInput();

--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -50,10 +50,12 @@ class LockboxPartner < ApplicationRecord
     end
   end
 
+  def minimum_acceptable_balance_formatted
+    Money.new(minimum_acceptable_balance)
+  end
+
   def low_balance?
-    balance < MINIMUM_ACCEPTABLE_BALANCE
-    # TODO after backfill
-    # balance.cents < minimum_acceptable_balance
+    balance.cents < minimum_acceptable_balance
   end
 
   def insufficient_funds?

--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -18,6 +18,7 @@ class LockboxPartner < ApplicationRecord
   RECONCILIATION_INTERVAL = 30
   DAYS_UNTIL_OVERDUE_RECONCILIATION_NOTIFICATION = 7
   MINIMUM_ACCEPTABLE_BALANCE = Money.new(50000) # $500
+  MINIMUM_ACCEPTABLE_BALANCE_RANGE = 100..1000
   THRESHOLD_FOR_RECENT_INITIAL_CASH_ADDITION_IN_HOURS = 48
   THRESHOLD_LONGSTANDING_CASH_ADDITION_IN_DAYS = 3
   ZERO_BALANCE = Money.new(0)
@@ -31,7 +32,7 @@ class LockboxPartner < ApplicationRecord
   end
 
   def set_defaults
-    self.minimum_acceptable_balance ||= MINIMUM_ACCEPTABLE_BALANCE
+    self.minimum_acceptable_balance ||= MINIMUM_ACCEPTABLE_BALANCE.cents
   end
 
   def pending_support_requests

--- a/app/views/lockbox_partners/_admin_alerts.html.erb
+++ b/app/views/lockbox_partners/_admin_alerts.html.erb
@@ -14,7 +14,7 @@
       <i class="fa fa-exclamation-circle alert-primary-icon" aria-hidden="true"></i>
     </div>
     <div class="p-2 flex-grow-1">
-      <div class="text-break"><%= lockbox_partner.name %>'s balance of $<%= lockbox_partner.balance %> is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. Please replenish the funds.</div>
+      <div class="text-break"><%= lockbox_partner.name %>'s balance of $<%= lockbox_partner.balance %> is below $<%= lockbox_partner.minimum_acceptable_balance_formatted %>. Please replenish the funds.</div>
     </div>
   </div>
 <% end %>

--- a/app/views/lockbox_partners/_alerts.html.erb
+++ b/app/views/lockbox_partners/_alerts.html.erb
@@ -50,7 +50,7 @@
     </div>
     <div class="p-2 flex-grow-1">
       <div class="text-break">
-        Your lockbox balance is below $<%= LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE %>. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email <%= link_to alert_email, "mailto:#{alert_email}" %>.
+        Your lockbox balance is below $<%= lockbox_partner.minimum_acceptable_balance_formatted %>. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email <%= link_to alert_email, "mailto:#{alert_email}" %>.
       </div>
     </div>
   </div>

--- a/app/views/lockbox_partners/_header.html.erb
+++ b/app/views/lockbox_partners/_header.html.erb
@@ -4,32 +4,43 @@
     <%= render partial: 'lockbox_partners/back_to_dashboard', locals: {:alignment => 'right'} %>
   <% end %>
   <span class="header-desktop">
-    <h2>
-      <%= lockbox_partner.name %>
-      <span class="float-right">
-        <i
-          class="fa fa-info-circle tooltip-icon"
-          tabindex="0"
-          data-toggle="tooltip"
-          data-placement="bottom"
-          data-animation="false"
-          title="The balance here includes all cash in the partner lockbox, minus any Pending Support Requests."
-        >
-        </i>
-        $<%= lockbox_partner.balance %>
-      </span>
-    </h2>
-    <div class="lockbox-partner-info">
-      <p class="address">
-        <% if lockbox_partner.street_address %>
-          <%= lockbox_partner.street_address %>
-          <br>
+    <div class="lockbox-partner-header-info">
+      <div>
+        <h2>
+          <%= lockbox_partner.name %>
+        </h2>
+        <div class="lockbox-partner-info">
+          <p class="address">
+            <% if lockbox_partner.street_address %>
+              <%= lockbox_partner.street_address %>
+              <br>
+            <% end %>
+            <%= lockbox_partner.city %>, <%= lockbox_partner.state %> <%= lockbox_partner.zip_code %>
+          </p>
+          <p class="phone_number">
+            <%= lockbox_partner.phone_number %>
+          </p>
+        </div>
+      </div>
+      <span>
+        <h2>
+          <i
+            class="fa fa-info-circle tooltip-icon"
+            tabindex="0"
+            data-toggle="tooltip"
+            data-placement="bottom"
+            data-animation="false"
+            title="The balance here includes all cash in the partner lockbox, minus any Pending Support Requests."
+          >
+          </i>
+          $<%= lockbox_partner.balance %>
+        </h2>
+        <div>Low balance alert:</div>
+        <%= link_to edit_lockbox_partner_path(lockbox_partner) do %>
+          <%= "$#{lockbox_partner.minimum_acceptable_balance_formatted}" %>
+          <i class="fa fa-edit" aria-hidden="true"></i>
         <% end %>
-        <%= lockbox_partner.city %>, <%= lockbox_partner.state %> <%= lockbox_partner.zip_code %>
-      </p>
-      <p class="phone_number">
-        <%= lockbox_partner.phone_number %>
-      </p>
+      </span>
     </div>
   </span>
   <span class="header-mobile">

--- a/app/views/lockbox_partners/_lockbox_partner_inputs.html.erb
+++ b/app/views/lockbox_partners/_lockbox_partner_inputs.html.erb
@@ -48,3 +48,12 @@
     class: 'form-control'
   %>
 </div>
+<div class="form-group">
+  <%= f.label :minimum_acceptable_balance %>
+  <p class="help-text">When the lockbox balance reaches this amount, notifications will be sent to the lockbox finance team and coordinators to send out more money.</p>
+  <%= f.text_field :minimum_acceptable_balance,
+    class: 'form-control d-none',
+    required: true
+  %>
+  <input id="minimum-acceptable-balance-formatted" type="number" class="form-control" value="" min="100" max="1000"/>
+</div>

--- a/app/views/lockbox_partners/_lockbox_partner_inputs.html.erb
+++ b/app/views/lockbox_partners/_lockbox_partner_inputs.html.erb
@@ -55,5 +55,5 @@
     class: 'form-control d-none',
     required: true
   %>
-  <input id="minimum-acceptable-balance-formatted" type="number" class="form-control" value="" min="100" max="1000"/>
+  <%= number_field_tag "minimum-acceptable-balance-formatted", "", class: "form-control", in: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE_RANGE %>
 </div>

--- a/spec/lib/create_support_request_spec.rb
+++ b/spec/lib/create_support_request_spec.rb
@@ -175,7 +175,7 @@ describe CreateSupportRequest do
     end
 
     before do
-      AddCashToLockbox.call!(lockbox_partner: low_balance_lockbox_partner, eff_date: 1.day.ago, amount: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE).complete!
+      AddCashToLockbox.call!(lockbox_partner: low_balance_lockbox_partner, eff_date: 1.day.ago, amount: lockbox_partner.minimum_acceptable_balance_formatted).complete!
     end
 
     it 'goes to the finance team when balance is below $300' do
@@ -186,7 +186,7 @@ describe CreateSupportRequest do
         drain_queues
       }.to change{ActionMailer::Base.deliveries.length}.by(3)
 
-      expected_dollar_value = (LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE - Money.new(100)).to_s
+      expected_dollar_value = (lockbox_partner.minimum_acceptable_balance_formatted - Money.new(100)).to_s
 
       emails = ActionMailer::Base.deliveries.last(3)
       mail = emails.detect {|e| e.subject.include?('[LOW LOCKBOX BALANCE]') }
@@ -210,7 +210,7 @@ describe CreateSupportRequest do
     it 'is not sent when the balance remains above $300' do
       stub_const('ENV', ENV.to_hash.merge('LOW_BALANCE_ALERT_EMAIL' => 'lowbalance@alert.com'))
 
-      AddCashToLockbox.call!(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE + Money.new(15000)).complete!
+      AddCashToLockbox.call!(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: lockbox_partner.minimum_acceptable_balance_formatted + Money.new(15000)).complete!
 
       params[:lockbox_action_attributes][:lockbox_transactions_attributes]["0"][:amount] = 100
       expect {

--- a/spec/models/lockbox_partner_spec.rb
+++ b/spec/models/lockbox_partner_spec.rb
@@ -526,7 +526,7 @@ describe LockboxPartner, type: :model do
     it 'is true when the balance is below $300' do
       lockbox_partner = FactoryBot.create(:lockbox_partner)
 
-      low_amount = LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE - Money.new(100)
+      low_amount = lockbox_partner.minimum_acceptable_balance_formatted - Money.new(100)
       AddCashToLockbox.call!(lockbox_partner: lockbox_partner, eff_date: 1.day.ago, amount: low_amount).complete!
       expect(lockbox_partner).to be_low_balance
 

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe "Dashboard", type: :system do
     context "when a partner has low balance" do
       # Expect 0 balance since there are no transactions
       it "alerts for low balance without cash addition" do
-        page.assert_text("#{lockbox_partner.name}'s balance of $#{lockbox_partner.balance} is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. Please replenish the funds.")
+        page.assert_text("#{lockbox_partner.name}'s balance of $#{lockbox_partner.balance} is below $#{lockbox_partner.minimum_acceptable_balance_formatted}. Please replenish the funds.")
       end
 
       it "alerts for low balance with unconfirmed cash addition" do
         submit_cash_addition
 
-        page.assert_text("#{lockbox_partner.name}'s balance of $#{lockbox_partner.balance} is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. Please replenish the funds.")
+        page.assert_text("#{lockbox_partner.name}'s balance of $#{lockbox_partner.balance} is below $#{lockbox_partner.minimum_acceptable_balance_formatted}. Please replenish the funds.")
       end
 
       it "doesn't alert for low balance with confirmed cash addition" do
@@ -41,7 +41,7 @@ RSpec.describe "Dashboard", type: :system do
 
         lockbox_partner.lockbox_actions.last.complete!
 
-        page.assert_no_text("#{lockbox_partner.name}'s balance of $#{lockbox_partner.balance} is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. Please replenish the funds.")
+        page.assert_no_text("#{lockbox_partner.name}'s balance of $#{lockbox_partner.balance} is below $#{lockbox_partner.minimum_acceptable_balance_formatted}. Please replenish the funds.")
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe "Dashboard", type: :system do
     context "when a partner has low balance" do
       # Expect 0 balance since there are no transactions
       it "alerts for low balance without cash addition" do
-        page.assert_text("Your lockbox balance is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email #{ENV['LOCKBOX_EMAIL']}.")
+        page.assert_text("Your lockbox balance is below $#{lockbox_partner.minimum_acceptable_balance_formatted}. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email #{ENV['LOCKBOX_EMAIL']}.")
       end
 
       it "removes alert for low balance with confirmed cash addition" do
@@ -71,11 +71,11 @@ RSpec.describe "Dashboard", type: :system do
           category: 'cash_addition'
         )
         visit("/")
-        page.assert_text("Your lockbox balance is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email #{ENV['LOCKBOX_EMAIL']}.")
+        page.assert_text("Your lockbox balance is below $#{lockbox_partner.minimum_acceptable_balance_formatted}. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email #{ENV['LOCKBOX_EMAIL']}.")
 
         click_link "Confirm Cash Addition"
 
-        page.assert_no_text("Your lockbox balance is below $#{LockboxPartner::MINIMUM_ACCEPTABLE_BALANCE}. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email #{ENV['LOCKBOX_EMAIL']}.")
+        page.assert_no_text("Your lockbox balance is below $#{lockbox_partner.minimum_acceptable_balance_formatted}. The lockbox manager should be reaching out to you shortly. If you haven't heard from them in a few days, please email #{ENV['LOCKBOX_EMAIL']}.")
       end
     end
 

--- a/spec/system/edit_lockbox_partner_spec.rb
+++ b/spec/system/edit_lockbox_partner_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require './lib/create_support_request'
+
+RSpec.describe "Edit lockbox partner", type: :system do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:lockbox_partner) { FactoryBot.create(:lockbox_partner) }
+  selector_string = "input:not([type=submit]):not([type=hidden]), select"
+
+  before do
+    login_as(user, :scope => :user)
+    visit("/lockbox_partners/#{lockbox_partner.id}")
+    click_link("$#{lockbox_partner.minimum_acceptable_balance_formatted}")
+  end
+
+  context "on submission of valid form" do
+    it "submission is successful" do
+      fill_in "Name", with: "Jo Momma"
+      fill_in "Street address", with: "123 Main Street"
+      fill_in "City", with: "Chicago"
+      select "Illinois", from: "State"
+      fill_in "Zip code", with: "60601"
+      fill_in "Phone number", with: "3123211234"
+      fill_in "minimum-acceptable-balance-formatted", with: "700"
+      click_button("Update Contact Info")
+      expect(page).to have_content("Contact information was successfully updated.")
+    end
+  end
+
+end

--- a/spec/system/new_lockbox_partner_spec.rb
+++ b/spec/system/new_lockbox_partner_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe "New lockbox partner form", type: :system do
 
   context "on initial page load" do
     it "all inputs are present" do
-      page.assert_selector(selector_string, count: 7)
+      page.assert_selector(selector_string, count: 8)
     end
 
     it "inputs are pristine" do
-      page.assert_selector(".pristine", count: 7)
+      page.assert_selector(".pristine", count: 8)
     end
   end
 
@@ -36,6 +36,7 @@ RSpec.describe "New lockbox partner form", type: :system do
       select "Illinois", from: "State"
       fill_in "Zip code", with: "60601"
       fill_in "Phone number", with: "3123211234"
+      fill_in "minimum-acceptable-balance-formatted", with: "500"
       click_button("Add New Partner")
       expect(page).to have_content("Lockbox Partner was successfully created.")
     end


### PR DESCRIPTION

## Changelog
- Added `minimum_acceptable_balance` field on new partner form
- Added `Low balance` link on partner show page
- Added minimum_acceptable_balance` field on "Update Contact Info" screen


## Link to issue:  
#371 
https://github.com/MidwestAccessCoalition/lockbox_rails/pull/556

## Steps for QA/Special Notes:
- Changes to new lockbox, show lockbox and edit lockbox screens

## Relevant Screenshots: 
<img width="688" alt="Screen Shot 2021-02-14 at 3 40 00 PM" src="https://user-images.githubusercontent.com/34173394/107892589-083c6100-6edb-11eb-923d-92d069bb45da.png">

---

<img width="712" alt="Screen Shot 2021-02-14 at 3 39 49 PM" src="https://user-images.githubusercontent.com/34173394/107892590-0a9ebb00-6edb-11eb-9d5b-449e260571ba.png">

---

<img width="492" alt="Screen Shot 2021-02-14 at 3 39 19 PM" src="https://user-images.githubusercontent.com/34173394/107892593-0c687e80-6edb-11eb-84b2-4b4e7a4c0d26.png">

---

## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [x] Added relevant screenshots
