### PR TITLE
Fix - Do not email locked acounts

### DIFF
--- a/app/mailers/lockbox_action_mailer.rb
+++ b/app/mailers/lockbox_action_mailer.rb
@@ -3,7 +3,7 @@ class LockboxActionMailer < ApplicationMailer
     @lockbox_partner = params[:lockbox_partner]
     @lockbox_action = params[:lockbox_action]
 
-    email_addresses = @lockbox_partner.users.confirmed.pluck(:email)
+    email_addresses = @lockbox_partner.users.active.pluck(:email)
     return if email_addresses.empty?
 
     mail(to: email_addresses, subject: 'Incoming Lockbox Cash in the Mail')

--- a/app/mailers/lockbox_partner_mailer.rb
+++ b/app/mailers/lockbox_partner_mailer.rb
@@ -3,7 +3,7 @@ class LockboxPartnerMailer < ApplicationMailer
     @lockbox_partner = params[:lockbox_partner]
     email_address = ENV['LOCKBOX_EMAIL']
     return unless email_address.present?
-    admin_emails = User.get_admin_emails
+    admin_emails = User.get_active_admin_emails
     subject = %Q(
       [INSUFFICIENT LOCKBOX FUNDS] #{@lockbox_partner.name} can't cover
       pending support requests
@@ -16,7 +16,7 @@ class LockboxPartnerMailer < ApplicationMailer
     @lockbox_partner = params[:lockbox_partner]
     email_address = [ENV['LOW_BALANCE_ALERT_EMAIL'], ENV['LOCKBOX_EMAIL']].join(",")
     return unless email_address.present?
-    admin_emails = User.get_admin_emails
+    admin_emails = User.get_active_admin_emails
     subject = "[LOW LOCKBOX BALANCE] #{@lockbox_partner.name} needs cash"
 
     mail(to: email_address, cc: admin_emails, subject: subject)

--- a/app/mailers/note_mailer.rb
+++ b/app/mailers/note_mailer.rb
@@ -46,7 +46,7 @@ class NoteMailer < ApplicationMailer
   def self.recipients(note)
     # MAC users only get emailed about manual notes
     # MAC users don't get emailed about notes they wrote
-    users = User.admin.all
+    users = User.admin.active
     users -= [note.user]
 
     # Partner users get emailed about all notes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,16 +6,16 @@ class User < ApplicationRecord
 
   # all but :omniauthable
   devise(
-    :authy_authenticatable, 
+    :authy_authenticatable,
     :authy_lockable,
     :confirmable,
     :database_authenticatable,
-    :lockable, 
-    :recoverable, 
-    :registerable, 
+    :lockable,
+    :recoverable,
+    :registerable,
     :rememberable,
     :timeoutable,
-    :trackable, 
+    :trackable,
     :validatable,
   )
 
@@ -41,6 +41,8 @@ class User < ApplicationRecord
   ].freeze
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
+
+  scope :active, -> { where(locked_at: nil).where.not(confirmed_at: nil) }
 
   def authy_enabled
     # This method overwrites devise-authy functionality to always return false
@@ -77,8 +79,8 @@ class User < ApplicationRecord
     self.name || "User #{id}"
   end
 
-  def self.get_admin_emails
-    User.admin.pluck(:email).join(",")
+  def self.get_active_admin_emails
+    User.admin.active.pluck(:email).join(",")
   end
 
   private

--- a/spec/lib/add_cash_to_lockbox_spec.rb
+++ b/spec/lib/add_cash_to_lockbox_spec.rb
@@ -3,6 +3,7 @@ require './lib/add_cash_to_lockbox'
 
 describe AddCashToLockbox do
   let(:lockbox_partner) { FactoryBot.create(:lockbox_partner, :with_active_user) }
+  let!(:locked_user) { create(:user, role: "partner", lockbox_partner: lockbox_partner, locked_at: Time.now) }
   let(:eff_date) { 1.day.from_now.to_date }
   let(:params) do
     {
@@ -44,11 +45,12 @@ describe AddCashToLockbox do
       expect{add_cash}.to change(TrackingInfo, :count).by(0)
     end
 
-    it "emails the lockbox partner's users" do
+    it "emails the lockbox partner's active users" do
       expect{ add_cash }.to change{ ActionMailer::Base.deliveries.count }.by(1)
       mail = ActionMailer::Base.deliveries.last
       expect(mail.subject).to eq('Incoming Lockbox Cash in the Mail')
       expect(mail.body).to include(amount)
+      expect(mail.to.to_s).not_to include(locked_user.email)
     end
 
     it "succeeds" do

--- a/spec/mailers/lockbox_partner_mailer_spec.rb
+++ b/spec/mailers/lockbox_partner_mailer_spec.rb
@@ -14,7 +14,9 @@ describe LockboxPartnerMailer, type: :mailer do
         .deliver_now
     end
 
-    let(:admin) { FactoryBot.create(:user) }
+    let!(:admin) { FactoryBot.create(:user) }
+
+    let!(:locked_admin) { FactoryBot.create(:user, locked_at: Time.now) }
 
     before do
       allow(ENV)
@@ -34,8 +36,9 @@ describe LockboxPartnerMailer, type: :mailer do
       expect(email.to).to eq([low_balance_alert_email, lockbox_email])
     end
 
-    it "ccs the admins" do
-      expect(admin.email).to eq(User.get_admin_emails)
+    it "ccs the active admin emails" do
+      expect(User.admin.count).to eq(2)
+      expect(admin.email).to eq(User.get_active_admin_emails)
       expect(email.cc).to eq([admin.email])
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,4 +68,19 @@ describe User, type: :model do
       it { is_expected.to eq('Lock Account') }
     end
   end
+
+  describe "scopes" do
+    let(:locked_user) { FactoryBot.create(:user, locked_at: Time.current) }
+    let(:active_user) { FactoryBot.create(:user) }
+    let(:unconfirmed_user) { FactoryBot.create(:user, confirmed_at: nil) }
+
+    context 'when user is confirmed and not locked' do
+      it "is active" do
+        active_users = User.active
+        expect(active_users).to include(active_user)
+        expect(active_users).to_not include(locked_user)
+        expect(active_users).to_not include(unconfirmed_user)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changelog
- Avoid sending notification emails to locked users (admins and partners)


## Link to issue:  
Fixes issue #596 


## Steps for QA/Special Notes:
- Should not see add cash notifications if the account is locked

## Relevant Screenshots: 
- super important for UI tasks!


## Are you ready for review?:

- [x] Added relevant tests
- [x] Linked PR to the issue
- [x] Added notes for QA/special notes
- [ ] Added relevant screenshots
