### PR TITLE
Update README Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,23 +84,7 @@ Or for RVM:
 rvm install
 ```
 
-#### Rails
-
-```sh
-gem install bundler -v 2.1.1
-bundle install # Make sure you're in the lockbox_rails root directory
-```
-
-#### Javascript
-You will need Yarn `v1.22.x`, a Node version manager (if you don't already have one, `nvm` is receommended), and Node `v11.x`.
-
-```sh
-brew install nvm yarn
-nvm install && nvm use # This will install and use the version in the project's `.nvmrc` file
-```
-
-#### PostgreSQL & DB setup
-
+#### PostgreSQL
 See if you have PostgreSQL:
 
 ```sh
@@ -115,6 +99,36 @@ brew services stop postgresql
 brew services start postgresql@11
 ```
 
+#### Rails
+
+```sh
+gem install bundler -v 2.1.1
+bundle install # Make sure you're in the lockbox_rails root directory
+```
+
+*If you get an error installing `pg` while running the `bundle install` command, it may be resolved 
+by running `brew install postgresql`, even if you have already installed `postgresql@11` or another 
+specific version of `postgresql`. Unlike when you installed `postgresql@11` above, you do not need 
+to start the `postgresql` service for this to fix your `bundle install` error.*
+
+#### Javascript
+You will need Yarn `v1.22.x`, a Node version manager (if you don't already have one, `nvm` is receommended), and Node `v11.x`.
+
+```sh
+brew install nvm yarn
+nvm install && nvm use # This will install and use the version in the project's `.nvmrc` file
+```
+#### Redis
+
+You'll need `redis` in order for `sidekiq` to work and to set up the database.
+
+```sh
+brew install redis
+brew services start redis
+```
+
+#### DB setup
+
 Setup DB:
 
 ```sh
@@ -126,10 +140,13 @@ _If you have issues at this step, see this [PostgreSQL Setup](https://github.com
 
 #### Mailcatcher
 
+This is done outside of the Gemfile because it is an
+external tool used outside of the app environment.
+The `--with-cflags="-Wno-error=implicit-function-declaration"` flag
+was added to avoid the error [described here](https://github.com/sj26/mailcatcher/issues/430).
+
 ```sh
-# This is done outside of the Gemfile because it is an
-# external tool used outside of the app environment.
-gem install mailcatcher
+gem install mailcatcher -- --with-cflags="-Wno-error=implicit-function-declaration"
 ```
 
 #### Webpack
@@ -159,15 +176,6 @@ bundle install # if necessary
 bundle exec rails s # or `yarn run dev:rails`
 # If testing email sending functionality, start mailcatcher
 mailcatcher # This will run on localhost:1080
-```
-
-#### Redis
-
-You'll need `redis` in order for `sidekiq` to work.
-
-```sh
-brew install redis
-brew services start redis
 ```
 
 #### Ports in use


### PR DESCRIPTION
See #614 for specifics, but I updated the README after running into installation issues.

I didn't include an update to fix the fact that the link to the PostgreSQL Setup doc can't be publicly reached. Do we care about that?

## Changelog
I updated the README installation instructions:
- Moved postgresql installation ahead of bundle install
- Added a note to bundle install in case of pg gem error
- Moved redis installation ahead of db setup
- Added flag to mailcatcher to avoid error

## Link to issue:  
Fixes issue #614 

## Steps for QA/Special Notes:
- Do we think these updates are universally relevant? I'm inclined to believe so because I set up my environment on a new laptop with nothing else installed,  but I'm curious what others think.

## Relevant Screenshots: 
PostgreSQL instructions being moved up and the note being added to bundle install in case of pg gem error
<img width="1008" alt="PostgreSQL and Rails Update" src="https://user-images.githubusercontent.com/18248193/126079032-5197a672-5563-4300-8c33-83eb6e59ba87.png">

Redis instructions being moved up, addition of the note about redis being necessary for database set up, and update of DB setup instructions now that the PostgreSQL instructions have been moved to a separate section
<img width="995" alt="Redis and DB Setup Update" src="https://user-images.githubusercontent.com/18248193/126079042-714632d2-a7e4-40f9-8302-e6d895699adb.png">

Mailcatcher instructions updated to include new flag
<img width="997" alt="Mailcatcher update" src="https://user-images.githubusercontent.com/18248193/126079058-ade15566-1ab4-4b3c-84b7-46e9565f9834.png">



## Are you ready for review?:

- [N/A ] Added relevant tests
- [X] Linked PR to the issue
- [X] Added notes for QA/special notes
- [X] Added relevant screenshots
