### PR TITLE
577 allow admin delete reconciliation

### DIFF
--- a/app/assets/stylesheets/lockbox_activity.scss
+++ b/app/assets/stylesheets/lockbox_activity.scss
@@ -17,6 +17,14 @@ tr.canceled {
   font-style: italic;
 }
 
+.deleted-reconciliation-tooltip-icon {
+  color: $color-primary;
+}
+
+.deleted-reconciliation-tooltip-text {
+  color: $color-primary;
+}
+
 .action-label {
   display: none;
 }

--- a/app/controllers/lockbox_actions_controller.rb
+++ b/app/controllers/lockbox_actions_controller.rb
@@ -19,7 +19,7 @@ class LockboxActionsController < ApplicationController
   end
 
   def update_params
-    params.require(:lockbox_action).permit(:status)
+    params.require(:lockbox_action).permit(:status, :delete_date, :delete_user)
   end
 
   def require_ownership

--- a/app/controllers/lockbox_partners/reconciliation_controller.rb
+++ b/app/controllers/lockbox_partners/reconciliation_controller.rb
@@ -19,6 +19,10 @@ class LockboxPartners::ReconciliationController < ApplicationController
     end
   end
 
+  def delete
+    @reconciliation = LockboxAction.find(params[:id])
+  end
+
   private
 
   def set_lockbox_partner

--- a/app/models/lockbox_action.rb
+++ b/app/models/lockbox_action.rb
@@ -106,6 +106,11 @@ class LockboxAction < ApplicationRecord
     lockbox_transactions.map(&:amount).sum
   end
 
+  def canceled_amount
+    return Money.zero if lockbox_transactions.none?
+    lockbox_transactions.map(&:amount).sum
+  end
+
   def pending?
     status == PENDING
   end

--- a/app/models/lockbox_partner.rb
+++ b/app/models/lockbox_partner.rb
@@ -137,7 +137,7 @@ class LockboxPartner < ApplicationRecord
   end
 
   def last_reconciled_at
-    lockbox_actions.where(action_type: LockboxAction::RECONCILE)
+    lockbox_actions.where(action_type: LockboxAction::RECONCILE, status: LockboxAction::COMPLETED)
                    .order(eff_date: :desc)
                    .first
                    &.eff_date

--- a/app/views/lockbox_partners/reconciliation/delete.html.erb
+++ b/app/views/lockbox_partners/reconciliation/delete.html.erb
@@ -1,0 +1,26 @@
+<%= render partial: 'lockbox_partners/header', locals: { lockbox_partner: @lockbox_partner } %>
+<%= form_for @reconciliation, html: { class: "form delete-reconciliation-form" } do |f| %>
+  <%= link_to lockbox_partner_path(@lockbox_partner) do |link| %>
+    <i class="fa fa-arrow-left" aria-hidden="true"></i> View All Activity
+  <% end %>
+  <div class="support-request-container">
+    <h2>Delete Reconciliation</h2>
+    <div class="row support-request-details">
+      <div class="col-12 col-md-6">
+        <strong>Delete Date</strong>
+        <p><%= @reconciliation&.eff_date %></p>
+      </div>
+      <div class="col-12 col-md-6">
+        <strong>Amount</strong>
+        <p>$<%= @reconciliation&.canceled_amount %></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="tab">
+    <%= link_to "Delete Reconciliation", lockbox_action_path(@reconciliation, {lockbox_action: {status: :canceled, delete_date: DateTime.current, delete_user: current_user.id}}), method: :put, class: "btn btn-danger" %>
+  </div>
+
+<% end %>
+
+<%= javascript_pack_tag 'forms', 'data-turbolinks-track': 'reload' %>

--- a/app/views/lockbox_partners/show.html.erb
+++ b/app/views/lockbox_partners/show.html.erb
@@ -18,18 +18,58 @@
       </thead>
       <tbody>
         <% @historical_actions.each do |action| %>
+          <% is_deleted_reconciliation = action.action_type == LockboxAction::RECONCILE && action.status == LockboxAction::CANCELED %>
           <tr class=<%= action.status %>>
-            <td><%= action.eff_date_formatted %></td>
-            <td><%= action.action_type.humanize %></td>
-            <td><%= action.status %></td>
+
             <td>
+              <% if is_deleted_reconciliation %>
+                <s>
+              <% end %>
+              <%= action.eff_date_formatted %>
+              <% if is_deleted_reconciliation %>
+                </s>
+              <% end %>
+            </td>
+
+            <td>
+              <% if is_deleted_reconciliation %>
+                <s>
+              <% end %>
+              <%= action.action_type.humanize %>
+              <% if is_deleted_reconciliation %>
+                </s>
+              <% end %>
+            </td>
+
+            <td>
+              <% if is_deleted_reconciliation %>
+                <s>
+              <% end %>
+              <%= action.status %>
+              <% if is_deleted_reconciliation %>
+                </s>
+              <% end %>
+            </td>
+
+            <td>
+              <% if is_deleted_reconciliation %>
+                <s>
+              <% end %>
               <% if action.credit? %>
                 +
               <% elsif action.debit? %>
                 -
               <% end %>
-              <%= action.amount %>
+              <% if is_deleted_reconciliation %>
+                <%= action.canceled_amount %>
+              <% else %>
+                <%= action.amount %>
+              <% end %>
+              <% if is_deleted_reconciliation %>
+                <s>
+              <% end %>
             </td>
+
             <td><%= action.support_request&.name_or_alias %></td>
             <td>
               <% if action.support_request %>
@@ -38,8 +78,32 @@
                   View details
                   <i class="fa fa-long-arrow-right" aria-hidden="true"></i>
                 <% end %>
-              <% end %>
-            </td>
+      			  <% elsif current_user.admin? && action.action_type == LockboxAction::RECONCILE && action.status == LockboxAction::COMPLETED %>
+              <!-- link to delete reconciliation page -->
+                  <% path = lockbox_partner_path+"/reconciliations/"+action.id.to_s+"/delete" %>
+      				    <%= link_to path do %>
+                    Delete Reconciliation
+                    <i class="fa fa-long-arrow-right" aria-hidden="true"></i>
+                  <% end %>
+              <% elsif is_deleted_reconciliation %>
+                <% reconciliation_delete_user_id = action.delete_user.nil? ? 0 : action.delete_user %>
+                <% reconciliation_delete_user = User.where(id: reconciliation_delete_user_id).first %>
+                <% reconciliation_delete_user_name = reconciliation_delete_user.nil? ? "" : reconciliation_delete_user.display_name.to_s %>
+                <div class="deleted-reconciliation-tooltip-icon">
+                  <i
+                    class="fa fa-info-circle tooltip-icon"
+                    tabindex="0"
+                    data-toggle="tooltip"
+                    data-placement="bottom"
+                    data-animation="false"
+                    data-html="true"
+                    title="<%= "<div class=\"deleted-reconciliation-tooltip-text\"><strong>History</strong><hr>Deleted date - " + action.delete_date.to_s + "<hr>User - " + reconciliation_delete_user_name + "</div>" %>"
+                  >
+                  </i>
+                  Deleted
+                </div>
+      			  <% end %>
+      			</td>
           </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,8 @@ Rails.application.routes.draw do
         resources :notes, only: [:create, :show, :edit, :update]
       end
       resource :add_cash, only: [:new, :create], controller: 'add_cash'
-      resource :reconciliation, only: [:new, :create], controller: 'reconciliation'
+      resource :reconciliation, only: [:new, :create, :edit, :update], controller: 'reconciliation'
+        get '/reconciliations/:id/delete', to: 'reconciliation#delete'
     end
   end
 

--- a/db/migrate/20210711200431_add_delete_date_and_user_to_lockbox_action.rb
+++ b/db/migrate/20210711200431_add_delete_date_and_user_to_lockbox_action.rb
@@ -1,0 +1,6 @@
+class AddDeleteDateAndUserToLockboxAction < ActiveRecord::Migration[6.0]
+  def change
+    add_column :lockbox_actions, :delete_date, :datetime
+    add_column :lockbox_actions, :delete_user, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_17_223939) do
+ActiveRecord::Schema.define(version: 2021_07_11_200431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 2021_01_17_223939) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "support_request_id"
     t.datetime "closed_at"
+    t.datetime "delete_date"
+    t.bigint "delete_user"
     t.index ["lockbox_partner_id"], name: "index_lockbox_actions_on_lockbox_partner_id"
     t.index ["support_request_id"], name: "index_lockbox_actions_on_support_request_id"
   end


### PR DESCRIPTION
(WIP currently, need to check on some tests that are failing after these changes)

## Changelog
- Added "Delete Reconciliation" button in "Actions" column of activity list, which goes to "Delete Reconciliation" page
- Canceled reconciliations show up as crossed out in the activity list (amount is not included in total balance, but it does show up in the table)
- Canceled reconciliations have "Deleted" icon in "Actions" column, which has a tooltip that says when/who deleted it (this is visible to both admins and partners)


## Link to issue:  
Fixes issue #577 


## Steps for QA/Special Notes:
- Reconcile as a lockbox partner
- Log in as admin user and delete the reconciliation


## Relevant Screenshots: 
A reconciliation before deleting, with admin user logged in:
![image](https://user-images.githubusercontent.com/22248856/126083654-8a2d5fea-181c-4b93-83a9-0a97ec97a98c.png)
Delete Reconciliation page:
![image](https://user-images.githubusercontent.com/22248856/126083665-8b723a83-9a0c-4f97-a4c9-e2c88750f8d3.png)
Reconciliation after deleting:
![image](https://user-images.githubusercontent.com/22248856/126083711-b02bafda-4115-473f-973f-d51b54851126.png)




## Are you ready for review?:

- [ ] Added relevant tests
- [ ] Linked PR to the issue
- [ ] Added notes for QA/special notes
- [ ] Added relevant screenshots
